### PR TITLE
Rollback egg version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,17 +33,17 @@ jobs:
 
       - name: "Synthesize rational rules"
         run: |
-          cargo rational --iters 2 --variables 3 --num-fuzz 50 --do-final-run --outfile out/rat.json
+          cargo rational --iters 2 --variables 3 --use-smt --do-final-run --outfile out/rat.json
           cargo run --release --bin rational derive --ci out/rat.json tests/rat.json out/rat-derive.json
 
       - name: "Synthesize rational rules (EMA)"
         run: |
-          cargo rational --iters 2 --variables 3 --ema-above-iter 1 --num-fuzz 50 --do-final-run --outfile out/rat-ema.json
+          cargo rational --iters 2 --variables 3 --ema-above-iter 1 --use-smt --do-final-run --outfile out/rat-ema.json
           cargo run --release --bin rational derive --ci out/rat-ema.json tests/rat-ema.json out/rat-ema-derive.json
 
       - name: "Synthesize rational rules (EMA, no consts)"
         run: |
-          cargo rational --iters 2 --variables 3 --ema-above-iter 1 --no-constants-above-iter 1 --num-fuzz 50 --do-final-run --outfile out/rat-ema-no-const.json
+          cargo rational --iters 2 --variables 3 --ema-above-iter 1 --no-constants-above-iter 1 --use-smt --do-final-run --outfile out/rat-ema-no-const.json
           cargo run --release --bin rational derive --ci out/rat-ema-no-const.json tests/rat-ema-no-const.json out/rat-ema-no-const-derive.json
 
       - name: "Synthesize bv4 rules"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,10 @@ symbolic_expressions = "5"
 rayon = "1"
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 
-egg = "0.7.1"
-
-#[dependencies.egg]
-#git = "https://github.com/egraphs-good/egg"
-#rev = "484fd6eec831a4078455ac47ef1172ede1b03dbf" # send sync
+[dependencies.egg]
+git = "https://github.com/egraphs-good/egg"
+rev = "8d68c8768cc18c2eae97f970e2b4162324cee787"   # 0.7-dev before proofs
+# rev = "484fd6eec831a4078455ac47ef1172ede1b03dbf" # send sync
 # rev = "116295f5c5afc58b34c732066c2e533bc4ad2ce8" # latest
 # rev = "483876ffc7e38a3d1e55a1f249dcd7900093b99e" # use more precise analysis rebuild
 # rev = "5d12e81a43d8eb6bfa8c29b62ba766143ba54a79" # Simplify unionfind

--- a/src/bin/trig.rs
+++ b/src/bin/trig.rs
@@ -186,7 +186,7 @@ define_language! {
 #[derive(Debug)]
 struct ComplexToRealApplier(&'static str);
 impl Applier<Math, SynthAnalysis> for ComplexToRealApplier {
-    fn apply_one(&self, egraph: &mut EGraph<Math, SynthAnalysis>, _: Id, subst: &Subst, _searcher_pat: Option<&PatternAst<Math>>, _rule: Symbol) -> Vec<Id> {
+    fn apply_one(&self, egraph: &mut EGraph<Math, SynthAnalysis>, _: Id, subst: &Subst) -> Vec<Id> {
         let id = subst[self.0.parse().unwrap()];
         if egraph[id].data.in_domain {
             return vec![];

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -77,8 +77,6 @@ impl<L: SynthLanguage> Applier<L, SynthAnalysis> for NotUndefined<L> {
         egraph: &mut EGraph<L, SynthAnalysis>,
         matched_id: Id,
         subst: &Subst,
-        searcher_ast: Option<&PatternAst<L>>,
-        rule_name: Symbol
     ) -> Vec<Id> {
         if !egraph[matched_id].data.is_defined() {
             return vec![];
@@ -104,7 +102,7 @@ impl<L: SynthLanguage> Applier<L, SynthAnalysis> for NotUndefined<L> {
             return vec![];
         }
 
-        let ids = self.rhs.apply_one(egraph, matched_id, subst, searcher_ast, rule_name);
+        let ids = self.rhs.apply_one(egraph, matched_id, subst);
         // assert_eq!(ids.len(), 1);
         if ids.len() == 0 {
             return vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,7 +639,7 @@ impl<L: SynthLanguage> Synthesizer<L> {
         layer.retain(|node| {
             let seen = &mut HashSet::<Id>::default();
             if iter > self.params.ema_above_iter {
-                let rec = node.join_recexprs(|id| self.egraph[id].data.simplest.as_ref());
+                let rec = node.to_recexpr(|id| self.egraph[id].data.simplest.as_ref());
                 let rec2 = L::emt_generalize(&rec);
                 let id = cp.add_expr(&rec2);
                 if usize::from(id) < max_id {
@@ -686,7 +686,7 @@ impl<L: SynthLanguage> Synthesizer<L> {
                 chunk_num += 1;
                 for node in chunk {
                     if iter > self.params.ema_above_iter {
-                        let rec = node.join_recexprs(|id| self.egraph[id].data.simplest.as_ref());
+                        let rec = node.to_recexpr(|id| self.egraph[id].data.simplest.as_ref());
                         self.egraph.add_expr(&L::emt_generalize(&rec));
                     } else {
                         self.egraph.add(node.clone());
@@ -867,7 +867,7 @@ impl<L: SynthLanguage> Synthesizer<L> {
                 chunk_num += 1;
                 for node in chunk {
                     if iter > self.params.ema_above_iter {
-                        let rec = node.join_recexprs(|id| self.egraph[id].data.simplest.as_ref());
+                        let rec = node.to_recexpr(|id| self.egraph[id].data.simplest.as_ref());
                         L::add_domain_expr(&mut self, &rec);
                     } else {
                         L::add_domain_node(&mut self, node.clone());
@@ -1283,7 +1283,7 @@ impl<L: SynthLanguage> Signature<L> {
 impl<L: SynthLanguage> egg::Analysis<L> for SynthAnalysis {
     type Data = Signature<L>;
 
-    fn merge(&mut self, to: &mut Self::Data, from: Self::Data) -> DidMerge {
+    fn merge(&self, to: &mut Self::Data, from: Self::Data) -> DidMerge {
         let mut merge_a = false;
         let cost_fn = |x: &RecExpr<L>| {
             if self.rule_lifting && L::recexpr_in_domain(x) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,7 +697,6 @@ impl<L: SynthLanguage> Synthesizer<L> {
                     let run_rewrites_before = Instant::now();
                     if !self.params.no_run_rewrites {
                         self.run_rewrites();
-                        self.egraph.rebuild();
                     }
                     let run_rewrites = run_rewrites_before.elapsed().as_secs_f64();
 
@@ -785,7 +784,6 @@ impl<L: SynthLanguage> Synthesizer<L> {
                         log::info!("Chose {} good rules", valid_eqs.len());
                         self.all_eqs.extend(valid_eqs.clone());
                         self.new_eqs.extend(valid_eqs);
-                        self.egraph.rebuild();
 
                         // TODO check formatting for Learned...
                         log::info!("Time taken in... rule minimization: {}", rule_minimize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -697,6 +697,7 @@ impl<L: SynthLanguage> Synthesizer<L> {
                     let run_rewrites_before = Instant::now();
                     if !self.params.no_run_rewrites {
                         self.run_rewrites();
+                        self.egraph.rebuild();
                     }
                     let run_rewrites = run_rewrites_before.elapsed().as_secs_f64();
 
@@ -784,6 +785,7 @@ impl<L: SynthLanguage> Synthesizer<L> {
                         log::info!("Chose {} good rules", valid_eqs.len());
                         self.all_eqs.extend(valid_eqs.clone());
                         self.new_eqs.extend(valid_eqs);
+                        self.egraph.rebuild();
 
                         // TODO check formatting for Learned...
                         log::info!("Time taken in... rule minimization: {}", rule_minimize);

--- a/tests/rat-ema.json
+++ b/tests/rat-ema.json
@@ -3,7 +3,7 @@
     "seed": 0,
     "n_samples": 0,
     "variables": 3,
-    "outfile": "tests/rat-ema.json",
+    "outfile": "out/rat-ema.json",
     "no_constant_fold": false,
     "iters": 2,
     "rules_to_take": 18446744073709551615,
@@ -25,93 +25,78 @@
     "complete_cvec": false,
     "no_xor": false,
     "no_shift": false,
-    "num_fuzz": 50,
-    "use_smt": false,
+    "num_fuzz": 0,
+    "use_smt": true,
     "do_final_run": true,
     "prior_rules": null
   },
-  "time": 4.815292659,
-  "num_rules": 37,
-  "smt_unknown": 0,
+  "time": 4.67382546,
+  "num_rules": 31,
+  "smt_unknown": 439,
   "all_eqs": [
     {
-      "lhs": "(* ?c (* ?b ?a))",
-      "rhs": "(* ?b (* ?a ?c))",
+      "lhs": "(* ?a (* ?b ?c))",
+      "rhs": "(* ?c (* ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?c (+ ?b ?a))",
-      "rhs": "(+ (+ ?c ?b) ?a)",
+      "lhs": "(+ ?a (+ ?b ?c))",
+      "rhs": "(+ ?c (+ ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (/ ?b ?a))",
-      "rhs": "(* ?a (/ ?c ?b))",
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(* ?c (/ ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(- (+ ?c ?b) ?a)",
-      "rhs": "(+ ?c (- ?b ?a))",
+      "lhs": "(- ?a (- ?b ?c))",
+      "rhs": "(+ ?c (- ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (* ?b ?a))",
-      "rhs": "(/ (/ ?c ?a) ?b)",
+      "lhs": "(/ ?a (* ?b ?c))",
+      "rhs": "(/ (/ ?a ?b) ?c)",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (- ?b ?a))",
-      "rhs": "(+ ?a (- ?c ?b))",
+      "lhs": "(- (+ ?a ?b) ?c)",
+      "rhs": "(+ ?a (- ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ (* ?c ?b) ?a)",
-      "rhs": "(* ?b (/ ?c ?a))",
+      "lhs": "(/ (* ?a ?b) ?c)",
+      "rhs": "(* ?a (/ ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (+ ?b ?a))",
-      "rhs": "(- (- ?c ?b) ?a)",
+      "lhs": "(- ?a (+ ?b ?c))",
+      "rhs": "(- (- ?a ?b) ?c)",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?b ?a)",
-      "rhs": "(+ ?a ?b)",
+      "lhs": "(+ ?a ?b)",
+      "rhs": "(+ ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b ?a)",
-      "rhs": "(* ?a ?b)",
+      "lhs": "(* ?a ?b)",
+      "rhs": "(* ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b (+ ?a ?a))",
-      "rhs": "(* ?a (+ ?b ?b))",
+      "lhs": "(* ?a (+ ?b ?b))",
+      "rhs": "(* ?b (+ ?a ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(/ (+ ?a ?b) ?a)",
-      "rhs": "(+ 1 (/ ?b ?a))",
+      "lhs": "(+ ?a (* ?a ?b))",
+      "rhs": "(* ?a (+ ?b 1))",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?b (* ?b ?a))",
-      "rhs": "(* ?b (+ ?a 1))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- ?a (* ?b ?a))",
+      "lhs": "(- ?a (* ?a ?b))",
       "rhs": "(* ?a (- 1 ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- ?b ?a) ?a)",
-      "rhs": "(+ -1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- (* ?a ?b) ?a)",
-      "rhs": "(* ?a (+ ?b -1))",
       "bidirectional": true
     },
     {
@@ -200,105 +185,75 @@
       "bidirectional": true
     },
     {
-      "lhs": "(fabs (/ -1 ?a))",
-      "rhs": "(/ 1 (fabs ?a))",
-      "bidirectional": true
-    },
-    {
       "lhs": "(fabs (/ 1 ?a))",
       "rhs": "(/ 1 (fabs ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- 1 ?a) ?a)",
-      "rhs": "(- -1 (/ -1 ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- 1 (/ -1 ?a))",
-      "rhs": "(+ 1 (/ 1 ?a))",
       "bidirectional": true
     }
   ],
   "new_eqs": [
     {
-      "lhs": "(* ?c (* ?b ?a))",
-      "rhs": "(* ?b (* ?a ?c))",
+      "lhs": "(* ?a (* ?b ?c))",
+      "rhs": "(* ?c (* ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?c (+ ?b ?a))",
-      "rhs": "(+ (+ ?c ?b) ?a)",
+      "lhs": "(+ ?a (+ ?b ?c))",
+      "rhs": "(+ ?c (+ ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (/ ?b ?a))",
-      "rhs": "(* ?a (/ ?c ?b))",
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(* ?c (/ ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(- (+ ?c ?b) ?a)",
-      "rhs": "(+ ?c (- ?b ?a))",
+      "lhs": "(- ?a (- ?b ?c))",
+      "rhs": "(+ ?c (- ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (* ?b ?a))",
-      "rhs": "(/ (/ ?c ?a) ?b)",
+      "lhs": "(/ ?a (* ?b ?c))",
+      "rhs": "(/ (/ ?a ?b) ?c)",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (- ?b ?a))",
-      "rhs": "(+ ?a (- ?c ?b))",
+      "lhs": "(- (+ ?a ?b) ?c)",
+      "rhs": "(+ ?a (- ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ (* ?c ?b) ?a)",
-      "rhs": "(* ?b (/ ?c ?a))",
+      "lhs": "(/ (* ?a ?b) ?c)",
+      "rhs": "(* ?a (/ ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (+ ?b ?a))",
-      "rhs": "(- (- ?c ?b) ?a)",
+      "lhs": "(- ?a (+ ?b ?c))",
+      "rhs": "(- (- ?a ?b) ?c)",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?b ?a)",
-      "rhs": "(+ ?a ?b)",
+      "lhs": "(+ ?a ?b)",
+      "rhs": "(+ ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b ?a)",
-      "rhs": "(* ?a ?b)",
+      "lhs": "(* ?a ?b)",
+      "rhs": "(* ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b (+ ?a ?a))",
-      "rhs": "(* ?a (+ ?b ?b))",
+      "lhs": "(* ?a (+ ?b ?b))",
+      "rhs": "(* ?b (+ ?a ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(/ (+ ?a ?b) ?a)",
-      "rhs": "(+ 1 (/ ?b ?a))",
+      "lhs": "(+ ?a (* ?a ?b))",
+      "rhs": "(* ?a (+ ?b 1))",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?b (* ?b ?a))",
-      "rhs": "(* ?b (+ ?a 1))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- ?a (* ?b ?a))",
+      "lhs": "(- ?a (* ?a ?b))",
       "rhs": "(* ?a (- 1 ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- ?b ?a) ?a)",
-      "rhs": "(+ -1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- (* ?a ?b) ?a)",
-      "rhs": "(* ?a (+ ?b -1))",
       "bidirectional": true
     },
     {
@@ -387,23 +342,8 @@
       "bidirectional": true
     },
     {
-      "lhs": "(fabs (/ -1 ?a))",
-      "rhs": "(/ 1 (fabs ?a))",
-      "bidirectional": true
-    },
-    {
       "lhs": "(fabs (/ 1 ?a))",
       "rhs": "(/ 1 (fabs ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- 1 ?a) ?a)",
-      "rhs": "(- -1 (/ -1 ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- 1 (/ -1 ?a))",
-      "rhs": "(+ 1 (/ 1 ?a))",
       "bidirectional": true
     }
   ],

--- a/tests/rat.json
+++ b/tests/rat.json
@@ -3,7 +3,7 @@
     "seed": 0,
     "n_samples": 0,
     "variables": 3,
-    "outfile": "tests/rat.json",
+    "outfile": "out/rat.json",
     "no_constant_fold": false,
     "iters": 2,
     "rules_to_take": 18446744073709551615,
@@ -25,118 +25,98 @@
     "complete_cvec": false,
     "no_xor": false,
     "no_shift": false,
-    "num_fuzz": 50,
-    "use_smt": false,
+    "num_fuzz": 0,
+    "use_smt": true,
     "do_final_run": true,
     "prior_rules": null
   },
-  "time": 14.376023172,
+  "time": 5.73958565,
   "num_rules": 40,
-  "smt_unknown": 0,
+  "smt_unknown": 502,
   "all_eqs": [
     {
-      "lhs": "(* ?c (* ?b ?a))",
-      "rhs": "(* ?b (* ?a ?c))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ ?c (/ ?b ?a))",
-      "rhs": "(/ ?a (/ ?b ?c))",
+      "lhs": "(/ (/ ?a ?b) ?c)",
+      "rhs": "(/ (/ ?a ?c) ?b)",
       "bidirectional": false
     },
     {
-      "lhs": "(/ (/ ?c ?b) ?a)",
-      "rhs": "(/ (/ ?c ?a) ?b)",
+      "lhs": "(- ?a (- ?b ?c))",
+      "rhs": "(- ?c (- ?b ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(- ?c (- ?b ?a))",
-      "rhs": "(- ?a (- ?b ?c))",
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(/ ?c (/ ?b ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(- (- ?c ?b) ?a)",
-      "rhs": "(- (- ?c ?a) ?b)",
+      "lhs": "(* ?a (* ?b ?c))",
+      "rhs": "(* ?c (* ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(- (- ?a ?b) ?c)",
+      "rhs": "(- (- ?a ?c) ?b)",
       "bidirectional": false
     },
     {
-      "lhs": "(+ ?c (+ ?b ?a))",
-      "rhs": "(+ ?a (+ ?b ?c))",
+      "lhs": "(+ ?a (+ ?b ?c))",
+      "rhs": "(+ ?b (+ ?a ?c))",
       "bidirectional": false
     },
     {
-      "lhs": "(/ (* ?c ?b) ?a)",
-      "rhs": "(* ?c (/ ?b ?a))",
+      "lhs": "(/ ?a (* ?b ?c))",
+      "rhs": "(/ (/ ?a ?c) ?b)",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (/ ?b ?a))",
-      "rhs": "(* ?a (/ ?c ?b))",
+      "lhs": "(/ (* ?a ?b) ?c)",
+      "rhs": "(* ?a (/ ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (* ?b ?a))",
-      "rhs": "(/ (/ ?c ?a) ?b)",
+      "lhs": "(- (+ ?a ?b) ?c)",
+      "rhs": "(+ ?a (- ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (- ?b ?a))",
-      "rhs": "(+ ?c (- ?a ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- ?c (- ?b ?a))",
+      "lhs": "(- ?a (- ?b ?c))",
       "rhs": "(- (+ ?c ?a) ?b)",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (+ ?b ?a))",
-      "rhs": "(- (- ?c ?b) ?a)",
+      "lhs": "(- ?a (+ ?b ?c))",
+      "rhs": "(- (- ?a ?b) ?c)",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?b ?a)",
-      "rhs": "(+ ?a ?b)",
+      "lhs": "(+ ?a ?b)",
+      "rhs": "(+ ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b ?a)",
-      "rhs": "(* ?a ?b)",
+      "lhs": "(* ?a ?b)",
+      "rhs": "(* ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(fabs (- ?b ?a))",
-      "rhs": "(fabs (- ?a ?b))",
+      "lhs": "(fabs (- ?a ?b))",
+      "rhs": "(fabs (- ?b ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b (+ ?a ?a))",
-      "rhs": "(* ?a (+ ?b ?b))",
+      "lhs": "(* ?a (+ ?b ?b))",
+      "rhs": "(* ?b (+ ?a ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(+ ?a (* ?b ?a))",
+      "lhs": "(+ ?a (* ?a ?b))",
       "rhs": "(* ?a (+ ?b 1))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ (- ?a ?b) ?a)",
-      "rhs": "(- 1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- ?a (* ?b ?a))",
+      "lhs": "(- ?a (* ?a ?b))",
       "rhs": "(* ?a (- 1 ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (+ ?a ?b) ?a)",
-      "rhs": "(+ 1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- ?b ?a) ?a)",
-      "rhs": "(+ -1 (/ ?b ?a))",
       "bidirectional": true
     },
     {
@@ -205,6 +185,11 @@
       "bidirectional": true
     },
     {
+      "lhs": "(/ (+ ?a ?a) ?a)",
+      "rhs": "2",
+      "bidirectional": false
+    },
+    {
       "lhs": "(* ?a 0)",
       "rhs": "0",
       "bidirectional": false
@@ -225,120 +210,115 @@
       "bidirectional": true
     },
     {
-      "lhs": "(fabs (/ 1 ?a))",
+      "lhs": "(fabs (/ -1 ?a))",
       "rhs": "(/ 1 (fabs ?a))",
       "bidirectional": true
     },
     {
-      "lhs": "(- -1 (/ -1 ?a))",
+      "lhs": "(/ (- -1 ?a) ?a)",
+      "rhs": "(+ -1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (+ ?a -1) ?a)",
+      "rhs": "(+ 1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (- 1 ?a) ?a)",
       "rhs": "(+ -1 (/ 1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (+ ?a 1) ?a)",
+      "rhs": "(- 1 (/ -1 ?a))",
       "bidirectional": true
     }
   ],
   "new_eqs": [
     {
-      "lhs": "(* ?c (* ?b ?a))",
-      "rhs": "(* ?b (* ?a ?c))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ ?c (/ ?b ?a))",
-      "rhs": "(/ ?a (/ ?b ?c))",
+      "lhs": "(/ (/ ?a ?b) ?c)",
+      "rhs": "(/ (/ ?a ?c) ?b)",
       "bidirectional": false
     },
     {
-      "lhs": "(/ (/ ?c ?b) ?a)",
-      "rhs": "(/ (/ ?c ?a) ?b)",
+      "lhs": "(- ?a (- ?b ?c))",
+      "rhs": "(- ?c (- ?b ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(- ?c (- ?b ?a))",
-      "rhs": "(- ?a (- ?b ?c))",
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(/ ?c (/ ?b ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(- (- ?c ?b) ?a)",
-      "rhs": "(- (- ?c ?a) ?b)",
+      "lhs": "(* ?a (* ?b ?c))",
+      "rhs": "(* ?c (* ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(- (- ?a ?b) ?c)",
+      "rhs": "(- (- ?a ?c) ?b)",
       "bidirectional": false
     },
     {
-      "lhs": "(+ ?c (+ ?b ?a))",
-      "rhs": "(+ ?a (+ ?b ?c))",
+      "lhs": "(+ ?a (+ ?b ?c))",
+      "rhs": "(+ ?b (+ ?a ?c))",
       "bidirectional": false
     },
     {
-      "lhs": "(/ (* ?c ?b) ?a)",
-      "rhs": "(* ?c (/ ?b ?a))",
+      "lhs": "(/ ?a (* ?b ?c))",
+      "rhs": "(/ (/ ?a ?c) ?b)",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (/ ?b ?a))",
-      "rhs": "(* ?a (/ ?c ?b))",
+      "lhs": "(/ (* ?a ?b) ?c)",
+      "rhs": "(* ?a (/ ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?c (* ?b ?a))",
-      "rhs": "(/ (/ ?c ?a) ?b)",
+      "lhs": "(- (+ ?a ?b) ?c)",
+      "rhs": "(+ ?a (- ?b ?c))",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (- ?b ?a))",
-      "rhs": "(+ ?c (- ?a ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- ?c (- ?b ?a))",
+      "lhs": "(- ?a (- ?b ?c))",
       "rhs": "(- (+ ?c ?a) ?b)",
       "bidirectional": true
     },
     {
-      "lhs": "(- ?c (+ ?b ?a))",
-      "rhs": "(- (- ?c ?b) ?a)",
+      "lhs": "(- ?a (+ ?b ?c))",
+      "rhs": "(- (- ?a ?b) ?c)",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?b ?a)",
-      "rhs": "(+ ?a ?b)",
+      "lhs": "(+ ?a ?b)",
+      "rhs": "(+ ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b ?a)",
-      "rhs": "(* ?a ?b)",
+      "lhs": "(* ?a ?b)",
+      "rhs": "(* ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(fabs (- ?b ?a))",
-      "rhs": "(fabs (- ?a ?b))",
+      "lhs": "(fabs (- ?a ?b))",
+      "rhs": "(fabs (- ?b ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(* ?b (+ ?a ?a))",
-      "rhs": "(* ?a (+ ?b ?b))",
+      "lhs": "(* ?a (+ ?b ?b))",
+      "rhs": "(* ?b (+ ?a ?a))",
       "bidirectional": false
     },
     {
-      "lhs": "(+ ?a (* ?b ?a))",
+      "lhs": "(+ ?a (* ?a ?b))",
       "rhs": "(* ?a (+ ?b 1))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ (- ?a ?b) ?a)",
-      "rhs": "(- 1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- ?a (* ?b ?a))",
+      "lhs": "(- ?a (* ?a ?b))",
       "rhs": "(* ?a (- 1 ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (+ ?a ?b) ?a)",
-      "rhs": "(+ 1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- ?b ?a) ?a)",
-      "rhs": "(+ -1 (/ ?b ?a))",
       "bidirectional": true
     },
     {
@@ -407,6 +387,11 @@
       "bidirectional": true
     },
     {
+      "lhs": "(/ (+ ?a ?a) ?a)",
+      "rhs": "2",
+      "bidirectional": false
+    },
+    {
       "lhs": "(* ?a 0)",
       "rhs": "0",
       "bidirectional": false
@@ -427,13 +412,28 @@
       "bidirectional": true
     },
     {
-      "lhs": "(fabs (/ 1 ?a))",
+      "lhs": "(fabs (/ -1 ?a))",
       "rhs": "(/ 1 (fabs ?a))",
       "bidirectional": true
     },
     {
-      "lhs": "(- -1 (/ -1 ?a))",
+      "lhs": "(/ (- -1 ?a) ?a)",
+      "rhs": "(+ -1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (+ ?a -1) ?a)",
+      "rhs": "(+ 1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (- 1 ?a) ?a)",
       "rhs": "(+ -1 (/ 1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (+ ?a 1) ?a)",
+      "rhs": "(- 1 (/ -1 ?a))",
       "bidirectional": true
     }
   ],

--- a/tests/real.json
+++ b/tests/real.json
@@ -3,7 +3,7 @@
     "seed": 0,
     "n_samples": 0,
     "variables": 3,
-    "outfile": "tests/real.json",
+    "outfile": "out/real.json",
     "no_constant_fold": false,
     "iters": 2,
     "rules_to_take": 18446744073709551615,
@@ -28,35 +28,50 @@
     "num_fuzz": 0,
     "use_smt": false,
     "do_final_run": false,
-    "prior_rules": "tests/rat.json"
+    "prior_rules": "out/rat.json"
   },
-  "time": 2.278555137,
-  "num_rules": 17,
+  "time": 2.55176668,
+  "num_rules": 28,
   "smt_unknown": 0,
   "all_eqs": [
     {
-      "lhs": "(+R ?c (+R ?b ?a))",
-      "rhs": "?c",
+      "lhs": "(-R (-R ?a ?b) ?c)",
+      "rhs": "(-R (-R ?a ?c) ?b)",
       "bidirectional": false
     },
     {
-      "lhs": "(+ ?a (+ ?b ?c))",
-      "rhs": "(+ ?c (+ ?b ?a))",
+      "lhs": "(+R ?a (+R ?b ?c))",
+      "rhs": "(+R ?c (+R ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/R ?a (/R ?b ?c))",
+      "rhs": "(/R ?c (/R ?b ?a))",
       "bidirectional": false
+    },
+    {
+      "lhs": "(-R ?a (-R ?b ?c))",
+      "rhs": "(-R ?c (-R ?b ?a))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(/R (/R ?a ?b) ?c)",
+      "rhs": "(/R (/R ?a ?c) ?b)",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(*R ?a (*R ?b ?c))",
+      "rhs": "(*R ?c (*R ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(+ ?a (+ ?b ?c))",
+      "rhs": "(+ ?c (+ ?a ?b))",
+      "bidirectional": true
     },
     {
       "lhs": "(- (- ?a ?b) ?c)",
       "rhs": "(- (- ?a ?c) ?b)",
-      "bidirectional": false
-    },
-    {
-      "lhs": "(- ?a (- ?b ?c))",
-      "rhs": "(- ?c (- ?b ?a))",
-      "bidirectional": false
-    },
-    {
-      "lhs": "(/ (/ ?a ?b) ?c)",
-      "rhs": "(/ (/ ?a ?c) ?b)",
       "bidirectional": false
     },
     {
@@ -70,9 +85,54 @@
       "bidirectional": true
     },
     {
+      "lhs": "(- ?a (- ?b ?c))",
+      "rhs": "(- ?c (- ?b ?a))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(/ (/ ?a ?b) ?c)",
+      "rhs": "(/ (/ ?a ?c) ?b)",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(/R ?a (/R ?b ?c))",
+      "rhs": "(*R ?c (/R ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/R (*R ?a ?b) ?c)",
+      "rhs": "(*R ?b (/R ?a ?c))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(-R ?a (-R ?b ?c))",
+      "rhs": "(-R (+R ?a ?c) ?b)",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(-R ?a (+R ?b ?c))",
+      "rhs": "(-R (-R ?a ?b) ?c)",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/R ?a (*R ?b ?c))",
+      "rhs": "(/R (/R ?a ?c) ?b)",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(+R ?a (-R ?b ?c))",
+      "rhs": "(+R ?b (-R ?a ?c))",
+      "bidirectional": false
+    },
+    {
       "lhs": "(- ?a (+ ?b ?c))",
       "rhs": "(- (- ?a ?b) ?c)",
       "bidirectional": true
+    },
+    {
+      "lhs": "(+ ?a (- ?b ?c))",
+      "rhs": "(+ ?b (- ?a ?c))",
+      "bidirectional": false
     },
     {
       "lhs": "(- ?a (- ?b ?c))",
@@ -80,8 +140,13 @@
       "bidirectional": true
     },
     {
-      "lhs": "(- ?a (- ?b ?c))",
-      "rhs": "(+ ?a (- ?c ?b))",
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(/ (* ?a ?c) ?b)",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(* ?a (/ ?c ?b))",
       "bidirectional": true
     },
     {
@@ -90,23 +155,13 @@
       "bidirectional": true
     },
     {
-      "lhs": "(/ ?a (/ ?b ?c))",
-      "rhs": "(* ?c (/ ?a ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (* ?a ?b) ?c)",
-      "rhs": "(* ?a (/ ?b ?c))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(+R ?b ?a)",
-      "rhs": "(+R ?a ?b)",
+      "lhs": "(*R ?a ?b)",
+      "rhs": "(*R ?b ?a)",
       "bidirectional": false
     },
     {
-      "lhs": "(*R ?b ?a)",
-      "rhs": "(*R ?a ?b)",
+      "lhs": "(+R ?a ?b)",
+      "rhs": "(+R ?b ?a)",
       "bidirectional": false
     },
     {
@@ -125,39 +180,49 @@
       "bidirectional": false
     },
     {
-      "lhs": "(/ (+ ?a ?b) ?a)",
-      "rhs": "(+ 1 (/ ?b ?a))",
-      "bidirectional": true
+      "lhs": "(+R ?a (-R ?b ?a))",
+      "rhs": "?b",
+      "bidirectional": false
     },
     {
-      "lhs": "(- ?a (* ?b ?a))",
+      "lhs": "(*R ?a (/R ?b ?b))",
+      "rhs": "?a",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(-R ?a (+R ?a ?b))",
+      "rhs": "(~R ?b)",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(*R ?a (+R ?b ?b))",
+      "rhs": "(*R ?b (+R ?a ?a))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(/R (/R ?a ?b) ?a)",
+      "rhs": "(/R ?b (*R ?b ?b))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(- ?a (* ?a ?b))",
       "rhs": "(* ?a (- 1 ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ (- ?a ?b) ?a)",
-      "rhs": "(- 1 (/ ?b ?a))",
+      "lhs": "(+ ?a (* ?a ?b))",
+      "rhs": "(* ?a (+ ?b 1))",
       "bidirectional": true
     },
     {
-      "lhs": "(+ ?a (* ?b ?a))",
-      "rhs": "(* ?a (+ ?b 1))",
+      "lhs": "(- (* ?a ?b) ?b)",
+      "rhs": "(* ?b (- ?a 1))",
       "bidirectional": true
     },
     {
       "lhs": "(* ?a (+ ?b ?b))",
       "rhs": "(* ?b (+ ?a ?a))",
       "bidirectional": false
-    },
-    {
-      "lhs": "(- (* ?a ?b) ?a)",
-      "rhs": "(* ?a (+ ?b -1))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- ?a ?b) ?b)",
-      "rhs": "(+ -1 (/ ?a ?b))",
-      "bidirectional": true
     },
     {
       "lhs": "(/ 0 ?a)",
@@ -220,11 +285,6 @@
       "bidirectional": true
     },
     {
-      "lhs": "(/R ?a ?a)",
-      "rhs": "(-R ?a ?a)",
-      "bidirectional": true
-    },
-    {
       "lhs": "(- ?a 1)",
       "rhs": "(+ ?a -1)",
       "bidirectional": true
@@ -240,7 +300,7 @@
       "bidirectional": true
     },
     {
-      "lhs": "(fabs (/ 1 ?a))",
+      "lhs": "(fabs (/ -1 ?a))",
       "rhs": "(/ 1 (fabs ?a))",
       "bidirectional": true
     },
@@ -250,14 +310,29 @@
       "bidirectional": true
     },
     {
-      "lhs": "(- -1 (/ -1 ?a))",
-      "rhs": "(+ -1 (/ 1 ?a))",
+      "lhs": "(/ (+ ?a ?a) ?a)",
+      "rhs": "2",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(/ (+ ?a -1) ?a)",
+      "rhs": "(+ 1 (/ -1 ?a))",
       "bidirectional": true
     },
     {
-      "lhs": "(-R ?a ?a)",
-      "rhs": "0R",
-      "bidirectional": false
+      "lhs": "(/ (- 1 ?a) ?a)",
+      "rhs": "(- -1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (+ ?a 1) ?a)",
+      "rhs": "(- 1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (- -1 ?a) ?a)",
+      "rhs": "(+ -1 (/ -1 ?a))",
+      "bidirectional": true
     },
     {
       "lhs": "?a",
@@ -265,9 +340,9 @@
       "bidirectional": true
     },
     {
-      "lhs": "(/R ?a ?a)",
-      "rhs": "1R",
-      "bidirectional": false
+      "lhs": "?a",
+      "rhs": "(-R ?a 0R)",
+      "bidirectional": true
     },
     {
       "lhs": "?a",
@@ -277,16 +352,6 @@
     {
       "lhs": "?a",
       "rhs": "(/R ?a 1R)",
-      "bidirectional": true
-    },
-    {
-      "lhs": "?a",
-      "rhs": "(-R ?a 0R)",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(~R ?a)",
-      "rhs": "(-R 0R ?a)",
       "bidirectional": true
     },
     {
@@ -300,14 +365,9 @@
       "bidirectional": true
     },
     {
-      "lhs": "(/R 0R ?a)",
-      "rhs": "(-R ?a ?a)",
+      "lhs": "(~R ?a)",
+      "rhs": "(-R 0R ?a)",
       "bidirectional": true
-    },
-    {
-      "lhs": "(*R ?a 0R)",
-      "rhs": "0R",
-      "bidirectional": false
     },
     {
       "lhs": "(-R ?a -1R)",
@@ -322,28 +382,98 @@
   ],
   "new_eqs": [
     {
-      "lhs": "(+R ?c (+R ?b ?a))",
-      "rhs": "?c",
+      "lhs": "(-R (-R ?a ?b) ?c)",
+      "rhs": "(-R (-R ?a ?c) ?b)",
       "bidirectional": false
     },
     {
-      "lhs": "(+R ?b ?a)",
-      "rhs": "(+R ?a ?b)",
-      "bidirectional": false
-    },
-    {
-      "lhs": "(*R ?b ?a)",
-      "rhs": "(*R ?a ?b)",
-      "bidirectional": false
-    },
-    {
-      "lhs": "(/R ?a ?a)",
-      "rhs": "(-R ?a ?a)",
+      "lhs": "(+R ?a (+R ?b ?c))",
+      "rhs": "(+R ?c (+R ?a ?b))",
       "bidirectional": true
     },
     {
-      "lhs": "(-R ?a ?a)",
-      "rhs": "0R",
+      "lhs": "(/R ?a (/R ?b ?c))",
+      "rhs": "(/R ?c (/R ?b ?a))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(-R ?a (-R ?b ?c))",
+      "rhs": "(-R ?c (-R ?b ?a))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(/R (/R ?a ?b) ?c)",
+      "rhs": "(/R (/R ?a ?c) ?b)",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(*R ?a (*R ?b ?c))",
+      "rhs": "(*R ?c (*R ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/R ?a (/R ?b ?c))",
+      "rhs": "(*R ?c (/R ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/R (*R ?a ?b) ?c)",
+      "rhs": "(*R ?b (/R ?a ?c))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(-R ?a (-R ?b ?c))",
+      "rhs": "(-R (+R ?a ?c) ?b)",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(-R ?a (+R ?b ?c))",
+      "rhs": "(-R (-R ?a ?b) ?c)",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/R ?a (*R ?b ?c))",
+      "rhs": "(/R (/R ?a ?c) ?b)",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(+R ?a (-R ?b ?c))",
+      "rhs": "(+R ?b (-R ?a ?c))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(*R ?a ?b)",
+      "rhs": "(*R ?b ?a)",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(+R ?a ?b)",
+      "rhs": "(+R ?b ?a)",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(+R ?a (-R ?b ?a))",
+      "rhs": "?b",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(*R ?a (/R ?b ?b))",
+      "rhs": "?a",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(-R ?a (+R ?a ?b))",
+      "rhs": "(~R ?b)",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(*R ?a (+R ?b ?b))",
+      "rhs": "(*R ?b (+R ?a ?a))",
+      "bidirectional": false
+    },
+    {
+      "lhs": "(/R (/R ?a ?b) ?a)",
+      "rhs": "(/R ?b (*R ?b ?b))",
       "bidirectional": false
     },
     {
@@ -352,9 +482,9 @@
       "bidirectional": true
     },
     {
-      "lhs": "(/R ?a ?a)",
-      "rhs": "1R",
-      "bidirectional": false
+      "lhs": "?a",
+      "rhs": "(-R ?a 0R)",
+      "bidirectional": true
     },
     {
       "lhs": "?a",
@@ -364,16 +494,6 @@
     {
       "lhs": "?a",
       "rhs": "(/R ?a 1R)",
-      "bidirectional": true
-    },
-    {
-      "lhs": "?a",
-      "rhs": "(-R ?a 0R)",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(~R ?a)",
-      "rhs": "(-R 0R ?a)",
       "bidirectional": true
     },
     {
@@ -387,14 +507,9 @@
       "bidirectional": true
     },
     {
-      "lhs": "(/R 0R ?a)",
-      "rhs": "(-R ?a ?a)",
+      "lhs": "(~R ?a)",
+      "rhs": "(-R 0R ?a)",
       "bidirectional": true
-    },
-    {
-      "lhs": "(*R ?a 0R)",
-      "rhs": "0R",
-      "bidirectional": false
     },
     {
       "lhs": "(-R ?a -1R)",
@@ -409,16 +524,6 @@
   ],
   "old_eqs": [
     {
-      "lhs": "(* ?a (* ?b ?c))",
-      "rhs": "(* ?c (* ?a ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ ?a (/ ?b ?c))",
-      "rhs": "(/ ?c (/ ?b ?a))",
-      "bidirectional": false
-    },
-    {
       "lhs": "(/ (/ ?a ?b) ?c)",
       "rhs": "(/ (/ ?a ?c) ?b)",
       "bidirectional": false
@@ -429,23 +534,23 @@
       "bidirectional": false
     },
     {
+      "lhs": "(* ?a (* ?b ?c))",
+      "rhs": "(* ?c (* ?a ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(/ ?c (/ ?b ?a))",
+      "bidirectional": false
+    },
+    {
       "lhs": "(- (- ?a ?b) ?c)",
       "rhs": "(- (- ?a ?c) ?b)",
       "bidirectional": false
     },
     {
       "lhs": "(+ ?a (+ ?b ?c))",
-      "rhs": "(+ ?c (+ ?b ?a))",
-      "bidirectional": false
-    },
-    {
-      "lhs": "(/ (* ?a ?b) ?c)",
-      "rhs": "(* ?a (/ ?b ?c))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ ?a (/ ?b ?c))",
-      "rhs": "(* ?c (/ ?a ?b))",
+      "rhs": "(+ ?c (+ ?a ?b))",
       "bidirectional": true
     },
     {
@@ -454,14 +559,24 @@
       "bidirectional": true
     },
     {
-      "lhs": "(- ?a (- ?b ?c))",
-      "rhs": "(+ ?a (- ?c ?b))",
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(* ?a (/ ?c ?b))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ ?a (/ ?b ?c))",
+      "rhs": "(/ (* ?a ?c) ?b)",
       "bidirectional": true
     },
     {
       "lhs": "(- ?a (- ?b ?c))",
       "rhs": "(- (+ ?a ?c) ?b)",
       "bidirectional": true
+    },
+    {
+      "lhs": "(+ ?a (- ?b ?c))",
+      "rhs": "(+ ?b (- ?a ?c))",
+      "bidirectional": false
     },
     {
       "lhs": "(- ?a (+ ?b ?c))",
@@ -489,33 +604,18 @@
       "bidirectional": false
     },
     {
-      "lhs": "(+ ?a (* ?b ?a))",
+      "lhs": "(- (* ?a ?b) ?b)",
+      "rhs": "(* ?b (- ?a 1))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(+ ?a (* ?a ?b))",
       "rhs": "(* ?a (+ ?b 1))",
       "bidirectional": true
     },
     {
-      "lhs": "(/ (- ?a ?b) ?a)",
-      "rhs": "(- 1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- ?a (* ?b ?a))",
+      "lhs": "(- ?a (* ?a ?b))",
       "rhs": "(* ?a (- 1 ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (+ ?a ?b) ?a)",
-      "rhs": "(+ 1 (/ ?b ?a))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(/ (- ?a ?b) ?b)",
-      "rhs": "(+ -1 (/ ?a ?b))",
-      "bidirectional": true
-    },
-    {
-      "lhs": "(- (* ?a ?b) ?a)",
-      "rhs": "(* ?a (+ ?b -1))",
       "bidirectional": true
     },
     {
@@ -579,6 +679,11 @@
       "bidirectional": true
     },
     {
+      "lhs": "(/ (+ ?a ?a) ?a)",
+      "rhs": "2",
+      "bidirectional": false
+    },
+    {
       "lhs": "(* ?a 0)",
       "rhs": "0",
       "bidirectional": false
@@ -599,13 +704,28 @@
       "bidirectional": true
     },
     {
-      "lhs": "(fabs (/ 1 ?a))",
+      "lhs": "(fabs (/ -1 ?a))",
       "rhs": "(/ 1 (fabs ?a))",
       "bidirectional": true
     },
     {
-      "lhs": "(- -1 (/ -1 ?a))",
-      "rhs": "(+ -1 (/ 1 ?a))",
+      "lhs": "(/ (- 1 ?a) ?a)",
+      "rhs": "(- -1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (- -1 ?a) ?a)",
+      "rhs": "(+ -1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (+ ?a -1) ?a)",
+      "rhs": "(+ 1 (/ -1 ?a))",
+      "bidirectional": true
+    },
+    {
+      "lhs": "(/ (+ ?a 1) ?a)",
+      "rhs": "(- 1 (/ -1 ?a))",
       "bidirectional": true
     }
   ]


### PR DESCRIPTION
This PR reverts the egg version to a pre-proof commit (8d68c8768cc18c2eae97f970e2b4162324cee787). The introduction of delayed unions and proofs in egg 0.7.x has led to mysterious problems within Ruler that have been difficult to diagnose. Until a solution can be found, using an older version of egg will have to suffice.