### PR TITLE
Enable running from a workload

### DIFF
--- a/src/bin/bool.rs
+++ b/src/bin/bool.rs
@@ -253,6 +253,7 @@ mod test {
             use_smt: false,
             do_final_run: true,
             prior_rules: None,
+            workload: String::from("terms.txt"),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,8 +792,8 @@ impl<L: SynthLanguage> Synthesizer<L> {
         }
     }
 
-    fn enumerate_workload(&self) -> Vec<RecExpr<L>> {
-        let infile = std::fs::File::open("./tests/terms.txt").expect("can't open file");
+    fn enumerate_workload(&self, filename: &str) -> Vec<RecExpr<L>> {
+        let infile = std::fs::File::open(filename).expect("can't open file");
         let reader = std::io::BufReader::new(infile);
         let mut terms = vec![];
         for line in std::io::BufRead::lines(reader) {
@@ -810,7 +810,7 @@ impl<L: SynthLanguage> Synthesizer<L> {
         let t = Instant::now();
 
         if self.params.iters == 0 {
-            let terms = self.enumerate_workload();
+            let terms = self.enumerate_workload(&self.params.workload);
             for chunk in terms.chunks(self.params.node_chunk_size) {
                 self.run_chunk(chunk, &mut poison_rules);
             }
@@ -1255,6 +1255,9 @@ pub struct SynthParams {
     ///////////////////
     #[clap(long)]
     pub prior_rules: Option<String>,
+
+    #[clap(long, default_value = "terms.txt")]
+    pub workload: String,
 }
 
 /// Derivability report.


### PR DESCRIPTION
2 main changes:
1. `enumerate_layer` now returns a `Vec<RecExpr<L>>` instead of `Vec<L>` and `add_chunk`/`run_chunk` expect `&[RecExpr<L>]` instead of `&[L]`. This is because we parse the workload terms into `RecExpr<L>` so it simplifies the code to make everything the same type.
2. If you set iters to 0 and supply a workload file, Ruler will run with the workload terms instead of standard enumeration.