### PR TITLE
Add Nat domain

### DIFF
--- a/src/bin/bigint.rs
+++ b/src/bin/bigint.rs
@@ -70,7 +70,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/bigint.rs
+++ b/src/bin/bigint.rs
@@ -70,7 +70,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/bool.rs
+++ b/src/bin/bool.rs
@@ -140,7 +140,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Lit(c)
     }
 

--- a/src/bin/bool.rs
+++ b/src/bin/bool.rs
@@ -140,7 +140,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::Lit(c)
     }
 

--- a/src/bin/bv-bool.rs
+++ b/src/bin/bv-bool.rs
@@ -88,7 +88,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/bv-bool.rs
+++ b/src/bin/bv-bool.rs
@@ -88,7 +88,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/complex-real.rs
+++ b/src/bin/complex-real.rs
@@ -359,7 +359,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::ComplexConst(c)
     }
 

--- a/src/bin/complex-real.rs
+++ b/src/bin/complex-real.rs
@@ -359,7 +359,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::ComplexConst(c)
     }
 

--- a/src/bin/float.rs
+++ b/src/bin/float.rs
@@ -103,7 +103,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/float.rs
+++ b/src/bin/float.rs
@@ -103,7 +103,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/nat.rs
+++ b/src/bin/nat.rs
@@ -110,11 +110,11 @@ impl SynthLanguage for Nat {
         }
     }
 
-    fn mk_constant(c: Self::Constant, egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         match c {
             0 => Nat::Z,
             _ => {
-                let pred = Self::mk_constant_id(c - 1, &mut egraph.clone());
+                let pred = Self::mk_constant_id(c - 1, egraph);
                 Nat::S(pred)
             }
         }

--- a/src/bin/nat.rs
+++ b/src/bin/nat.rs
@@ -1,0 +1,174 @@
+use egg::*;
+use rand::RngCore;
+use ruler::*;
+
+define_language! {
+  pub enum Nat {
+    "Z" = Z,
+    "S" = S(Id),
+    "+" = Add([Id; 2]),
+    Var(egg::Symbol),
+  }
+}
+
+impl Nat {
+    fn mk_constant_id(c: usize, egraph: &mut EGraph<Self, SynthAnalysis>) -> Id {
+        match c {
+            0 => egraph.add(Nat::Z),
+            _ => {
+                let pred = Self::mk_constant_id(c - 1, egraph);
+                egraph.add(Nat::S(pred))
+            }
+        }
+    }
+}
+
+impl SynthLanguage for Nat {
+    type Constant = usize;
+
+    fn convert_parse(s: &str) -> RecExpr<Self> {
+        s.parse().unwrap()
+    }
+
+    fn eval<'a, F>(&'a self, cvec_len: usize, mut v: F) -> CVec<Self>
+    where
+        F: FnMut(&'a Id) -> &'a CVec<Self>,
+    {
+        match self {
+            Nat::Z => vec![Some(0); cvec_len],
+            Nat::S(x) => map!(v, x => Some(*x + 1)),
+            Nat::Add([a, b]) => map!(v, a, b => Some(*a + *b)),
+            Nat::Var(_) => vec![],
+        }
+    }
+
+    fn mk_interval(&self, egraph: &EGraph<Self, SynthAnalysis>) -> Interval<Self::Constant> {
+        match self {
+            Nat::Var(_) => Interval::new(Some(0), None),
+            Nat::Z => Interval::new(Some(0), Some(0)),
+            Nat::S(x) => {
+                let x_int = egraph[*x].data.interval.clone();
+                if let Some(l) = x_int.low {
+                    Interval::new(Some(l + 1), x_int.high.map(|v| v + 1))
+                } else {
+                    panic!("There shouldn't be infinite lower bounds for Nats")
+                }
+            }
+            Nat::Add([x, y]) => {
+                let x_int = egraph[*x].data.interval.clone();
+                let y_int = egraph[*y].data.interval.clone();
+
+                let low = match (x_int.low, y_int.low) {
+                    (Some(a), Some(b)) => Some(a + b),
+                    (_, _) => panic!("There shouldn't be infinite lower bounds for Nats"),
+                };
+
+                let high = match (x_int.high, y_int.high) {
+                    (Some(a), Some(b)) => Some(a + b),
+                    (_, _) => None,
+                };
+                Interval::new(low, high)
+            }
+        }
+    }
+
+    fn to_var(&self) -> Option<Symbol> {
+        if let Nat::Var(sym) = self {
+            Some(*sym)
+        } else {
+            None
+        }
+    }
+
+    fn mk_var(sym: egg::Symbol) -> Self {
+        Nat::Var(sym)
+    }
+
+    fn to_constant(&self) -> Option<&Self::Constant> {
+        if let Nat::Z = self {
+            Some(&0)
+        } else {
+            // TODO: Should we try to do something smarter here to get constants like S (S Z)?
+            None
+        }
+    }
+
+    fn mk_constant(c: Self::Constant, egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+        match c {
+            0 => Nat::Z,
+            _ => {
+                let pred = Self::mk_constant_id(c - 1, &mut egraph.clone());
+                Nat::S(pred)
+            }
+        }
+    }
+
+    fn init_synth(synth: &mut Synthesizer<Self>) {
+        let mut egraph: EGraph<Nat, SynthAnalysis> = EGraph::new(SynthAnalysis {
+            cvec_len: 10,
+            constant_fold: ConstantFoldMethod::IntervalAnalysis,
+            rule_lifting: false,
+        });
+
+        for i in 0..synth.params.variables {
+            let var = Symbol::from(letter(i));
+            let id = egraph.add(Nat::Var(var));
+            let mut vals = vec![];
+            let rng = &mut synth.rng;
+
+            for _ in 0..10 {
+                vals.push(Some(rng.next_u32() as usize));
+            }
+            egraph[id].data.cvec = vals.clone();
+        }
+        synth.egraph = egraph;
+    }
+
+    fn make_layer(_synth: &Synthesizer<Self>, _iter: usize) -> Vec<Self> {
+        // TODO - Do we need this if we'll always be using workloads?
+        vec![]
+    }
+
+    fn validate(
+        _synth: &mut Synthesizer<Self>,
+        _lhs: &Pattern<Self>,
+        _rhs: &Pattern<Self>,
+    ) -> ValidationResult {
+        // TODO
+        ValidationResult::Valid
+    }
+}
+
+fn main() {
+    Nat::main()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn mk_constant_id() {
+        let mut egraph: EGraph<Nat, SynthAnalysis> = EGraph::new(SynthAnalysis {
+            cvec_len: 1,
+            constant_fold: ConstantFoldMethod::NoFold,
+            rule_lifting: false,
+        });
+        let zero = egraph.add(Nat::Z);
+        let one = egraph.add(Nat::S(zero));
+        let two = egraph.add(Nat::S(one));
+        let three = egraph.add(Nat::S(two));
+
+        let zero_c = Nat::mk_constant_id(0, &mut egraph.clone());
+        assert_eq!(zero, zero_c);
+
+        let one_c = Nat::mk_constant_id(1, &mut egraph.clone());
+        assert_eq!(one, one_c);
+
+        let two_c = Nat::mk_constant_id(2, &mut egraph.clone());
+        assert_eq!(two, two_c);
+
+        let three_c = Nat::mk_constant_id(3, &mut egraph.clone());
+        assert_eq!(three, three_c);
+    }
+}

--- a/src/bin/nat.rs
+++ b/src/bin/nat.rs
@@ -7,6 +7,7 @@ define_language! {
     "Z" = Z,
     "S" = S(Id),
     "+" = Add([Id; 2]),
+    "*" = Mul([Id; 2]),
     Var(egg::Symbol),
   }
 }
@@ -38,6 +39,7 @@ impl SynthLanguage for Nat {
             Nat::Z => vec![Some(0); cvec_len],
             Nat::S(x) => map!(v, x => Some(*x + 1)),
             Nat::Add([a, b]) => map!(v, a, b => Some(*a + *b)),
+            Nat::Mul([a, b]) => map!(v, a, b => Some(*a * *b)),
             Nat::Var(_) => vec![],
         }
     }
@@ -65,6 +67,21 @@ impl SynthLanguage for Nat {
 
                 let high = match (x_int.high, y_int.high) {
                     (Some(a), Some(b)) => Some(a + b),
+                    (_, _) => None,
+                };
+                Interval::new(low, high)
+            }
+            Nat::Mul([x, y]) => {
+                let x_int = egraph[*x].data.interval.clone();
+                let y_int = egraph[*y].data.interval.clone();
+
+                let low = match (x_int.low, y_int.low) {
+                    (Some(a), Some(b)) => Some(a * b),
+                    (_, _) => panic!("There shouldn't be infinite lower bounds for Nats"),
+                };
+
+                let high = match (x_int.high, y_int.high) {
+                    (Some(a), Some(b)) => Some(a * b),
                     (_, _) => None,
                 };
                 Interval::new(low, high)

--- a/src/bin/pos-lift.rs
+++ b/src/bin/pos-lift.rs
@@ -1,0 +1,194 @@
+use egg::*;
+use ruler::*;
+
+define_language! {
+  pub enum Math {
+    // Nat
+    "Z" = Z,
+    "S" = S(Id),
+
+    // TODO (find equivs between Nat ops and Pos ops)
+    // Nat Ops
+    "PlusN" = PlusN([Id;2]),
+    "TimesN" = TimesN([Id;2]),
+
+    // Pos
+    "XH" = XH,
+    "XO" = XO(Id),
+    "XI" = XI(Id),
+
+    // Pos Ops
+    "+" = Add([Id; 2]),
+    "*" = Mul([Id; 2]),
+
+    Var(egg::Symbol),
+  }
+}
+
+impl Math {
+    fn mk_constant_id(c: usize, egraph: &mut EGraph<Self, SynthAnalysis>) -> Id {
+        if c == 0 {
+            egraph.add(Math::Z)
+        } else if c == 1 {
+            egraph.add(Math::XH)
+        } else if c < 1 {
+            panic!("invalid c")
+        } else if c % 2 == 0 {
+            let pred = Self::mk_constant_id(c / 2, egraph);
+            egraph.add(Math::XO(pred))
+        } else {
+            let pred = Self::mk_constant_id((c - 1) / 2, egraph);
+            egraph.add(Math::XI(pred))
+        }
+    }
+}
+
+impl SynthLanguage for Math {
+    type Constant = usize;
+
+    // No eval
+    fn eval<'a, F>(&'a self, _cvec_len: usize, _f: F) -> CVec<Self>
+    where
+        F: FnMut(&'a Id) -> &'a CVec<Self>,
+    {
+        vec![]
+    }
+
+    fn to_var(&self) -> Option<Symbol> {
+        if let Math::Var(sym) = self {
+            Some(*sym)
+        } else {
+            None
+        }
+    }
+
+    fn mk_var(sym: egg::Symbol) -> Self {
+        Math::Var(sym)
+    }
+
+    fn to_constant(&self) -> Option<&Self::Constant> {
+        match self {
+            Math::Z => Some(&0),
+            Math::XH => Some(&1),
+            _ => None,
+        }
+    }
+
+    fn mk_constant(c: Self::Constant, egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
+        if c == 1 {
+            Math::XH
+        } else if c < 1 {
+            panic!("invalid constant");
+        } else {
+            if c % 2 == 0 {
+                Math::XO(Self::mk_constant_id(c / 2, egraph))
+            } else {
+                Math::XI(Self::mk_constant_id((c - 1) / 2, egraph))
+            }
+        }
+    }
+
+    fn is_allowed(&self) -> bool {
+        matches!(
+            self,
+            Math::XH | Math::XO(_) | Math::XI(_) | Math::Add(_) | Math::Mul(_) | Math::Var(_)
+        )
+    }
+
+    fn is_extractable(&self) -> bool {
+        matches!(
+            self,
+            Math::XH | Math::XO(_) | Math::XI(_) | Math::Add(_) | Math::Mul(_) | Math::Var(_)
+        )
+    }
+
+    fn init_synth(synth: &mut Synthesizer<Self>) {
+        let mut egraph: EGraph<Math, SynthAnalysis> = EGraph::new(SynthAnalysis {
+            cvec_len: 0,
+            constant_fold: ConstantFoldMethod::NoFold,
+            rule_lifting: true,
+        });
+
+        synth.lifting_rewrites = vec![
+            rewrite!("def-xh"; "XH" <=> "(S Z)"),
+            // rewrite!("def-xo-mul"; "(XO ?a)" <=> "(* ?a (S (S Z)))"),
+            rewrite!("def-xo-add"; "(XO ?a)" <=> "(+ ?a ?a)"),
+            // rewrite!("def-xi-mul"; "(XI ?a)" <=> "(+ (* ?a (S (S Z))) (S Z))"),
+            rewrite!("def-xi-add"; "(XI ?a)" <=> "(+ ?a (+ ?a (S Z)))"),
+        ]
+        .concat();
+
+        synth.egraph = egraph;
+    }
+
+    fn make_layer(synth: &Synthesizer<Self>, iter: usize) -> Vec<Self> {
+        vec![]
+    }
+
+    fn validate(
+        synth: &mut Synthesizer<Self>,
+        lhs: &Pattern<Self>,
+        rhs: &Pattern<Self>,
+    ) -> ValidationResult {
+        ValidationResult::Valid
+    }
+
+    fn is_allowed_rewrite(lhs: &Pattern<Self>, rhs: &Pattern<Self>) -> bool {
+        let contains_pos_node = |pat: &Pattern<Self>| {
+            pat.ast.as_ref().iter().any(|n| {
+                matches!(
+                    n,
+                    ENodeOrVar::ENode(Math::XH)
+                        | ENodeOrVar::ENode(Math::XO(_))
+                        | ENodeOrVar::ENode(Math::XI(_))
+                )
+            })
+        };
+
+        let pattern_is_extractable = |pat: &Pattern<Self>| {
+            pat.ast.as_ref().iter().all(|n| {
+                println!("n: {}", n);
+                match n {
+                    ENodeOrVar::Var(_) => true,
+                    ENodeOrVar::ENode(n) => n.is_extractable(),
+                }
+            })
+        };
+
+        pattern_is_extractable(lhs)
+            && pattern_is_extractable(rhs)
+            && (contains_pos_node(lhs) || contains_pos_node(rhs))
+    }
+}
+
+fn main() {
+    Math::main()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn is_extractable() {
+        let mut egraph: EGraph<Math, SynthAnalysis> = EGraph::new(SynthAnalysis {
+            cvec_len: 1,
+            constant_fold: ConstantFoldMethod::NoFold,
+            rule_lifting: true,
+        });
+        let z = Math::Z;
+        assert!(!z.is_extractable());
+        let z_id = egraph.add(z);
+
+        let sz = Math::S(z_id);
+        assert!(!sz.is_extractable());
+        let sz_id = egraph.add(sz);
+
+        let one = Math::XH;
+        assert!(one.is_extractable());
+        let one_id = egraph.add(one);
+
+        let add = Math::Add([sz_id, one_id]);
+        assert!(!add.is_extractable());
+    }
+}

--- a/src/bin/pos.rs
+++ b/src/bin/pos.rs
@@ -1,0 +1,150 @@
+use egg::*;
+use rand::RngCore;
+use ruler::*;
+
+define_language! {
+  pub enum Pos {
+    "XH" = XH,
+    "XO" = XO(Id),
+    "XI" = XI(Id),
+    "+" = Add([Id;2]),
+    "*" = Mul([Id;2]),
+    Var(egg::Symbol),
+  }
+}
+
+impl Pos {
+    fn mk_constant_id(c: usize, egraph: &mut EGraph<Self, SynthAnalysis>) -> Id {
+        if c == 1 {
+            egraph.add(Pos::XH)
+        } else if c < 1 {
+            panic!("invalid pos")
+        } else if c % 2 == 0 {
+            let pred = Self::mk_constant_id(c / 2, egraph);
+            egraph.add(Pos::XO(pred))
+        } else {
+            let pred = Self::mk_constant_id((c - 1) / 2, egraph);
+            egraph.add(Pos::XI(pred))
+        }
+    }
+}
+
+impl SynthLanguage for Pos {
+    type Constant = usize;
+
+    fn eval<'a, F>(&'a self, cvec_len: usize, mut v: F) -> CVec<Self>
+    where
+        F: FnMut(&'a Id) -> &'a CVec<Self>,
+    {
+        match self {
+            Pos::XH => vec![Some(1); cvec_len],
+            Pos::XO(p) => map!(v, p => Some(*p * 2)),
+            Pos::XI(p) => map!(v, p => Some(*p * 2 + 1)),
+            Pos::Add([a, b]) => map!(v, a, b => Some(*a + *b)),
+            Pos::Mul([a, b]) => map!(v, a, b => Some(*a * *b)),
+            Pos::Var(_) => vec![],
+        }
+    }
+
+    fn to_var(&self) -> Option<Symbol> {
+        if let Pos::Var(sym) = self {
+            Some(*sym)
+        } else {
+            None
+        }
+    }
+
+    fn mk_var(sym: egg::Symbol) -> Self {
+        Pos::Var(sym)
+    }
+
+    fn to_constant(&self) -> Option<&Self::Constant> {
+        if let Pos::XH = self {
+            Some(&1)
+        } else {
+            None
+        }
+    }
+
+    fn mk_constant(c: Self::Constant, egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
+        if c == 1 {
+            Pos::XH
+        } else if c < 1 {
+            panic!("invalid constant");
+        } else {
+            if c % 2 == 0 {
+                Pos::XO(Self::mk_constant_id(c / 2, egraph))
+            } else {
+                Pos::XI(Self::mk_constant_id((c - 1) / 2, egraph))
+            }
+        }
+    }
+
+    fn init_synth(synth: &mut Synthesizer<Self>) {
+        let mut egraph: EGraph<Pos, SynthAnalysis> = EGraph::new(SynthAnalysis {
+            cvec_len: 10,
+            constant_fold: ConstantFoldMethod::IntervalAnalysis,
+            rule_lifting: false,
+        });
+
+        for i in 0..synth.params.variables {
+            let var = Symbol::from(letter(i));
+            let id = egraph.add(Pos::Var(var));
+            let mut vals = vec![];
+            let rng = &mut synth.rng;
+
+            for _ in 0..10 {
+                vals.push(Some(rng.next_u32() as usize));
+            }
+            egraph[id].data.cvec = vals.clone();
+        }
+        synth.egraph = egraph;
+    }
+
+    fn make_layer(_synth: &Synthesizer<Self>, _iter: usize) -> Vec<Self> {
+        vec![]
+    }
+
+    fn validate(
+        _synth: &mut Synthesizer<Self>,
+        _lhs: &Pattern<Self>,
+        _rhs: &Pattern<Self>,
+    ) -> ValidationResult {
+        // TODO
+        ValidationResult::Valid
+    }
+}
+
+fn main() {
+    Pos::main()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn mk_constant_id() {
+        let mut egraph: EGraph<Pos, SynthAnalysis> = EGraph::new(SynthAnalysis {
+            cvec_len: 1,
+            constant_fold: ConstantFoldMethod::NoFold,
+            rule_lifting: false,
+        });
+
+        let one = egraph.add(Pos::XH);
+        let two = egraph.add(Pos::XO(one));
+        let three = egraph.add(Pos::XI(one));
+        let four = egraph.add(Pos::XO(two));
+        let five = egraph.add(Pos::XI(two));
+        let six = egraph.add(Pos::XO(three));
+        let seven = egraph.add(Pos::XI(three));
+
+        assert_eq!(one, Pos::mk_constant_id(1, &mut egraph.clone()));
+        assert_eq!(two, Pos::mk_constant_id(2, &mut egraph.clone()));
+        assert_eq!(three, Pos::mk_constant_id(3, &mut egraph.clone()));
+        assert_eq!(four, Pos::mk_constant_id(4, &mut egraph.clone()));
+        assert_eq!(five, Pos::mk_constant_id(5, &mut egraph.clone()));
+        assert_eq!(six, Pos::mk_constant_id(6, &mut egraph.clone()));
+        assert_eq!(seven, Pos::mk_constant_id(7, &mut egraph.clone()));
+    }
+}

--- a/src/bin/rational-new-div.rs
+++ b/src/bin/rational-new-div.rs
@@ -113,7 +113,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/rational-new-div.rs
+++ b/src/bin/rational-new-div.rs
@@ -113,7 +113,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/rational.rs
+++ b/src/bin/rational.rs
@@ -275,7 +275,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/rational.rs
+++ b/src/bin/rational.rs
@@ -275,7 +275,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/real-rat.rs
+++ b/src/bin/real-rat.rs
@@ -232,7 +232,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::Rat(c)
     }
 

--- a/src/bin/real-rat.rs
+++ b/src/bin/real-rat.rs
@@ -232,7 +232,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Rat(c)
     }
 

--- a/src/bin/str.rs
+++ b/src/bin/str.rs
@@ -192,7 +192,7 @@ impl SynthLanguage for Lang {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Lang::Lit(c)
     }
 

--- a/src/bin/str.rs
+++ b/src/bin/str.rs
@@ -192,7 +192,7 @@ impl SynthLanguage for Lang {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Lang::Lit(c)
     }
 

--- a/src/bin/trig.rs
+++ b/src/bin/trig.rs
@@ -202,7 +202,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::RealConst(c)
     }
 
@@ -679,8 +679,10 @@ impl SynthLanguage for Math {
             if let Math::RealConst(n) = v {
                 if let Ok(x) = real_to_rational(&n) {
                     if x.is_negative() {
-                        let pos_id =
-                            egraph.add(Self::mk_constant(Real::from((-x).to_string()), egraph));
+                        let pos_id = egraph.add(Self::mk_constant(
+                            Real::from((-x).to_string()),
+                            &mut egraph.clone(),
+                        ));
                         let neg_id = egraph.add(Math::Neg(pos_id));
                         egraph.union(neg_id, id);
                     }

--- a/src/bin/trig.rs
+++ b/src/bin/trig.rs
@@ -202,7 +202,7 @@ impl SynthLanguage for Math {
         }
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
         Math::RealConst(c)
     }
 
@@ -611,7 +611,7 @@ impl SynthLanguage for Math {
                     if let Some(v) = extract_constant(&egraph[*i].nodes) {
                         if let Ok(x) = real_to_rational(&v) {
                             let r = Real::from((-x).to_string());
-                            to_add = Some(Self::mk_constant(r));
+                            to_add = Some(Self::mk_constant(r, egraph));
                             break;
                         }
                     }
@@ -622,7 +622,7 @@ impl SynthLanguage for Math {
                             if let Ok(x) = real_to_rational(&v) {
                                 if let Ok(y) = real_to_rational(&w) {
                                     let r = Real::from((x + y).to_string());
-                                    to_add = Some(Self::mk_constant(r));
+                                    to_add = Some(Self::mk_constant(r, egraph));
                                     break;
                                 }
                             }
@@ -635,7 +635,7 @@ impl SynthLanguage for Math {
                             if let Ok(x) = real_to_rational(&v) {
                                 if let Ok(y) = real_to_rational(&w) {
                                     let r = Real::from((x - y).to_string());
-                                    to_add = Some(Self::mk_constant(r));
+                                    to_add = Some(Self::mk_constant(r, egraph));
                                     break;
                                 }
                             }
@@ -648,7 +648,7 @@ impl SynthLanguage for Math {
                             if let Ok(x) = real_to_rational(&v) {
                                 if let Ok(y) = real_to_rational(&w) {
                                     let r = Real::from((x * y).to_string());
-                                    to_add = Some(Self::mk_constant(r));
+                                    to_add = Some(Self::mk_constant(r, egraph));
                                     break;
                                 }
                             }
@@ -662,7 +662,7 @@ impl SynthLanguage for Math {
                                 if let Ok(y) = real_to_rational(&w) {
                                     if !y.is_zero() {
                                         let r = Real::from((x / y).to_string());
-                                        to_add = Some(Self::mk_constant(r));
+                                        to_add = Some(Self::mk_constant(r, egraph));
                                         break;
                                     }
                                 }
@@ -679,7 +679,8 @@ impl SynthLanguage for Math {
             if let Math::RealConst(n) = v {
                 if let Ok(x) = real_to_rational(&n) {
                     if x.is_negative() {
-                        let pos_id = egraph.add(Self::mk_constant(Real::from((-x).to_string())));
+                        let pos_id =
+                            egraph.add(Self::mk_constant(Real::from((-x).to_string()), egraph));
                         let neg_id = egraph.add(Math::Neg(pos_id));
                         egraph.union(neg_id, id);
                     }

--- a/src/bv.rs
+++ b/src/bv.rs
@@ -220,7 +220,7 @@ macro_rules! impl_bv {
                 }
             }
 
-            fn mk_constant(c: Self::Constant) -> Self {
+            fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
                 Math::Num(c)
             }
 

--- a/src/bv.rs
+++ b/src/bv.rs
@@ -220,7 +220,7 @@ macro_rules! impl_bv {
                 }
             }
 
-            fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self {
+            fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
                 Math::Num(c)
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub trait SynthLanguage: egg::Language + Send + Sync + Display + FromOp + 'stati
     }
 
     fn to_constant(&self) -> Option<&Self::Constant>;
-    fn mk_constant(c: Self::Constant) -> Self;
+    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self;
     fn is_constant(&self) -> bool {
         self.to_constant().is_some()
     }
@@ -1577,7 +1577,7 @@ impl<L: SynthLanguage> egg::Analysis<L> for SynthAnalysis {
                 if sig.exact {
                     let first = sig.cvec.iter().find_map(|x| x.as_ref());
                     if let Some(first) = first {
-                        let enode = L::mk_constant(first.clone());
+                        let enode = L::mk_constant(first.clone(), egraph);
                         let added = egraph.add(enode);
                         egraph.union(id, added);
                     }
@@ -1591,7 +1591,7 @@ impl<L: SynthLanguage> egg::Analysis<L> for SynthAnalysis {
                 } = interval
                 {
                     if a == b {
-                        let enode = L::mk_constant(a.clone());
+                        let enode = L::mk_constant(a.clone(), egraph);
                         let added = egraph.add(enode);
                         egraph.union(id, added);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub trait SynthLanguage: egg::Language + Send + Sync + Display + FromOp + 'stati
     }
 
     fn to_constant(&self) -> Option<&Self::Constant>;
-    fn mk_constant(c: Self::Constant, _egraph: &EGraph<Self, SynthAnalysis>) -> Self;
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self;
     fn is_constant(&self) -> bool {
         self.to_constant().is_some()
     }


### PR DESCRIPTION
To discuss: I had to change the signature of `mk_constant` to take in the egraph to make it possible to recursively construct the Nat term. Is this okay? I couldn't think of another way to do it, but it does require changing the signature across all domains so not sure if it's a change we want to make.

With a corresponding workload of 5 atom terms, finds these rules:
```
(* ?c (* ?b ?a)) ==> (* ?a (* ?b ?c))
(+ ?c (+ ?b ?a)) ==> (+ ?a (+ ?b ?c))
(* ?b ?a) ==> (* ?a ?b)
(+ ?b ?a) ==> (+ ?a ?b)
(+ ?b (S ?a)) ==> (+ ?a (S ?b))
(S (+ ?b ?a)) <=> (+ ?a (S ?b))
(+ ?a (* ?b ?a)) <=> (* ?a (S ?b))
?a <=> (+ ?a Z)
?a <=> (* ?a (S Z))
(* ?a Z) ==> Z
```

