### PR TITLE
is_constant instead of to_constant

### DIFF
--- a/src/bin/bigint.rs
+++ b/src/bin/bigint.rs
@@ -62,12 +62,8 @@ impl SynthLanguage for Math {
         Math::Var(sym)
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::Num(n) = self {
-            Some(n)
-        } else {
-            None
-        }
+    fn is_constant(&self) -> bool {
+        matches!(self, Math::Num(_))
     }
 
     fn mk_constant(c: Self::Constant) -> Self {

--- a/src/bin/bool.rs
+++ b/src/bin/bool.rs
@@ -132,12 +132,8 @@ impl SynthLanguage for Math {
         Math::Var(sym)
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::Lit(n) = self {
-            Some(n)
-        } else {
-            None
-        }
+    fn is_constant(&self) -> bool {
+        matches!(self, Math::Lit(_))
     }
 
     fn mk_constant(c: Self::Constant) -> Self {

--- a/src/bin/bv-bool.rs
+++ b/src/bin/bv-bool.rs
@@ -80,12 +80,8 @@ impl SynthLanguage for Math {
         Math::Var(sym)
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::Num(n) = self {
-            Some(n)
-        } else {
-            None
-        }
+    fn is_constant(&self) -> bool {
+        matches!(self, Math::Num(_))
     }
 
     fn mk_constant(c: Self::Constant) -> Self {

--- a/src/bin/complex-real.rs
+++ b/src/bin/complex-real.rs
@@ -351,19 +351,10 @@ impl SynthLanguage for Math {
         Math::Var(Variable(sym))
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::ComplexConst(n) = self {
-            Some(n)
-        } else {
-            None
-        }
-    }
-
     fn mk_constant(c: Self::Constant) -> Self {
         Math::ComplexConst(c)
     }
 
-    // override default behavior
     fn is_constant(&self) -> bool {
         matches!(self, Math::ComplexConst(_))
     }

--- a/src/bin/float.rs
+++ b/src/bin/float.rs
@@ -95,12 +95,8 @@ impl SynthLanguage for Math {
         Math::Var(sym)
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::Num(n) = self {
-            Some(n)
-        } else {
-            None
-        }
+    fn is_constant(&self) -> bool {
+        matches!(self, Math::Num(_))
     }
 
     fn mk_constant(c: Self::Constant) -> Self {

--- a/src/bin/rational-new-div.rs
+++ b/src/bin/rational-new-div.rs
@@ -286,7 +286,7 @@ pub fn sampler(rng: &mut Pcg64, b1: u64, b2: u64, num_samples: usize) -> Vec<Rat
 }
 
 /// Convert expressions to Z3's syntax for using SMT based rule verification.
-#[allow(unused_mut, mutable_borrow_reservation_conflict)] // please remove if changing this
+#[allow(unused_mut)] // please remove if changing this
 fn egg_to_z3<'a>(
     ctx: &'a z3::Context,
     expr: &[Math],

--- a/src/bin/rational-new-div.rs
+++ b/src/bin/rational-new-div.rs
@@ -105,12 +105,8 @@ impl SynthLanguage for Math {
         Math::Var(sym)
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::Num(n) = self {
-            Some(n)
-        } else {
-            None
-        }
+    fn is_constant(&self) -> bool {
+        matches!(self, Math::Num(_))
     }
 
     fn mk_constant(c: Self::Constant) -> Self {

--- a/src/bin/rational.rs
+++ b/src/bin/rational.rs
@@ -267,12 +267,8 @@ impl SynthLanguage for Math {
         Math::Var(sym)
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::Num(n) = self {
-            Some(n)
-        } else {
-            None
-        }
+    fn is_constant(&self) -> bool {
+        matches!(self, Math::Num(_))
     }
 
     fn mk_constant(c: Self::Constant) -> Self {

--- a/src/bin/real-rat.rs
+++ b/src/bin/real-rat.rs
@@ -224,19 +224,10 @@ impl SynthLanguage for Math {
         Math::Var(Variable(sym))
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::Rat(n) = self {
-            Some(n)
-        } else {
-            None
-        }
-    }
-
     fn mk_constant(c: Self::Constant) -> Self {
         Math::Rat(c)
     }
 
-    // override default behavior
     fn is_constant(&self) -> bool {
         matches!(self, Math::Real(_))
     }

--- a/src/bin/str.rs
+++ b/src/bin/str.rs
@@ -184,12 +184,8 @@ impl SynthLanguage for Lang {
         Lang::Var(sym)
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Lang::Lit(n) = self {
-            Some(n)
-        } else {
-            None
-        }
+    fn is_constant(&self) -> bool {
+        matches!(self, Lang::Lit(_))
     }
 
     fn mk_constant(c: Self::Constant) -> Self {

--- a/src/bin/trig.rs
+++ b/src/bin/trig.rs
@@ -194,19 +194,10 @@ impl SynthLanguage for Math {
         Math::Var(Variable::from(sym.as_str()))
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant> {
-        if let Math::RealConst(n) = self {
-            Some(n)
-        } else {
-            None
-        }
-    }
-
     fn mk_constant(c: Self::Constant) -> Self {
         Math::RealConst(c)
     }
 
-    // override default behavior
     fn is_constant(&self) -> bool {
         matches!(self, Math::RealConst(_))
     }

--- a/src/bv.rs
+++ b/src/bv.rs
@@ -212,12 +212,8 @@ macro_rules! impl_bv {
                 Math::Var(sym)
             }
 
-            fn to_constant(&self) -> Option<&Self::Constant> {
-                if let Math::Num(n) = self {
-                    Some(n)
-                } else {
-                    None
-                }
+            fn is_constant(&self) -> bool {
+                matches!(self, Math::Num(_))
             }
 
             fn mk_constant(c: Self::Constant) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,11 +123,8 @@ pub trait SynthLanguage: egg::Language + Send + Sync + Display + FromOp + 'stati
         PatternAst::from(nodes).into()
     }
 
-    fn to_constant(&self) -> Option<&Self::Constant>;
     fn mk_constant(c: Self::Constant) -> Self;
-    fn is_constant(&self) -> bool {
-        self.to_constant().is_some()
-    }
+    fn is_constant(&self) -> bool;
 
     /// Generalize a pattern
     fn generalize(expr: &RecExpr<Self>, map: &mut HashMap<Symbol, Var>) -> Pattern<Self> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use rand_pcg::Pcg64;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::{Borrow, Cow},
-    fmt::{Debug, Display},
+    fmt::{Debug, Display, Write},
     hash::{BuildHasherDefault, Hash},
     sync::Arc,
     time::{Duration, Instant},
@@ -1819,11 +1819,11 @@ pub fn assert_eqs_same<L: SynthLanguage>(actual: &[Equality<L>], expected: &[Equ
 
     let mut missing = String::new();
     for rule in expected.difference(&actual) {
-        missing.push_str(&format!("  {}\n", rule));
+        let _ = writeln!(&mut missing, "  {}", rule);
     }
     let mut unexpected = String::new();
     for rule in actual.difference(&expected) {
-        unexpected.push_str(&format!("  {}\n", rule));
+        let _ = writeln!(&mut unexpected , "  {}", rule);
     }
     if missing.len() + unexpected.len() > 0 {
         panic!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1823,7 +1823,7 @@ pub fn assert_eqs_same<L: SynthLanguage>(actual: &[Equality<L>], expected: &[Equ
     }
     let mut unexpected = String::new();
     for rule in actual.difference(&expected) {
-        let _ = writeln!(&mut unexpected , "  {}", rule);
+        let _ = writeln!(&mut unexpected, "  {}", rule);
     }
     if missing.len() + unexpected.len() > 0 {
         panic!(


### PR DESCRIPTION
I think `to_constant` is only used by `is_constant` so we can probably just implement `is_constant` in each domain directly. This seems like a harmless little cleanup, but please let me know if there's some context I'm missing!