### PR TITLE
Switch pred to use rats not usize

### DIFF
--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -227,7 +227,7 @@ impl SynthLanguage for Pred {
     fn init_synth(synth: &mut Synthesizer<Self>) {
         let cvec_len = 300;
         let mut egraph: EGraph<Pred, SynthAnalysis> = EGraph::new(SynthAnalysis {
-            cvec_len: cvec_len,
+            cvec_len,
             constant_fold: ConstantFoldMethod::CvecMatching,
             rule_lifting: false,
         });

--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use egg::*;
-use rand::Rng;
+use num::bigint::{BigInt, RandBigInt, Sign, ToBigInt};
+use num::rational::Ratio;
+use rand::{seq::SliceRandom, Rng};
 use rand_pcg::Pcg64;
 use ruler::*;
 
@@ -33,20 +35,20 @@ impl FromStr for BVar {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 
-pub struct IVar(egg::Symbol);
+pub struct NVar(egg::Symbol);
 
-impl Display for IVar {
+impl Display for NVar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "i")
+        write!(f, "n")
     }
 }
 
-impl FromStr for IVar {
+impl FromStr for NVar {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with('i') {
-            Ok(IVar(Symbol::from(s)))
+        if s.starts_with('n') {
+            Ok(NVar(Symbol::from(s)))
         } else {
             Err(())
         }
@@ -57,7 +59,7 @@ define_language! {
   pub enum Pred {
     Lit(Constant),
     BVar(BVar),
-    IVar(IVar),
+    NVar(NVar),
     "<" = Le([Id;2]),
     "<=" = Leq([Id;2]),
     ">" = Ge([Id;2]),
@@ -74,14 +76,14 @@ define_language! {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Constant {
     Bool(bool),
-    Int(usize),
+    Num(Ratio<BigInt>),
 }
 
 impl fmt::Display for Constant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Constant::Bool(b) => b.fmt(f),
-            Constant::Int(i) => i.fmt(f),
+            Constant::Num(i) => i.fmt(f),
         }
     }
 }
@@ -89,8 +91,8 @@ impl fmt::Display for Constant {
 impl std::str::FromStr for Constant {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(i) = usize::from_str(s) {
-            Ok(Self::Int(i))
+        if let Ok(i) = Ratio::<BigInt>::from_str(s) {
+            Ok(Self::Num(i))
         } else if let Ok(b) = bool::from_str(s) {
             Ok(Self::Bool(b))
         } else {
@@ -100,9 +102,9 @@ impl std::str::FromStr for Constant {
 }
 
 impl Constant {
-    fn to_int(&self) -> Option<usize> {
+    fn to_num(&self) -> Option<Ratio<BigInt>> {
         match self {
-            Constant::Int(n) => Some(*n),
+            Constant::Num(n) => Some(n.clone()),
             Constant::Bool(_) => None,
         }
     }
@@ -110,7 +112,7 @@ impl Constant {
     fn to_bool(&self) -> Option<bool> {
         match self {
             Constant::Bool(b) => Some(*b),
-            Constant::Int(_) => None,
+            Constant::Num(_) => None,
         }
     }
 }
@@ -118,14 +120,14 @@ impl Constant {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Type {
     Bool,
-    Int,
+    Num,
 }
 
 impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Type::Bool => write!(f, "b"),
-            Type::Int => write!(f, "i"),
+            Type::Num => write!(f, "n"),
         }
     }
 }
@@ -138,9 +140,9 @@ impl SynthLanguage for Pred {
         match self {
             Pred::Lit(c) => match c {
                 Constant::Bool(_) => Type::Bool,
-                Constant::Int(_) => Type::Int,
+                Constant::Num(_) => Type::Num,
             },
-            Pred::IVar(_) => Type::Int,
+            Pred::NVar(_) => Type::Num,
             _ => Type::Bool,
         }
     }
@@ -152,22 +154,22 @@ impl SynthLanguage for Pred {
         match self {
             Pred::Lit(c) => vec![Some(c.clone()); cvec_len],
             Pred::Le([x, y]) => {
-                map!(v, x, y => Some(Constant::Bool(x.to_int().unwrap() < y.to_int().unwrap())))
+                map!(v, x, y => Some(Constant::Bool(x.to_num().unwrap() < y.to_num().unwrap())))
             }
             Pred::Leq([x, y]) => {
-                map!(v, x, y => Some(Constant::Bool(x.to_int().unwrap() <= y.to_int().unwrap())))
+                map!(v, x, y => Some(Constant::Bool(x.to_num().unwrap() <= y.to_num().unwrap())))
             }
             Pred::Ge([x, y]) => {
-                map!(v, x, y => Some(Constant::Bool(x.to_int().unwrap() > y.to_int().unwrap())))
+                map!(v, x, y => Some(Constant::Bool(x.to_num().unwrap() > y.to_num().unwrap())))
             }
             Pred::Geq([x, y]) => {
-                map!(v, x, y => Some(Constant::Bool(x.to_int().unwrap() >= y.to_int().unwrap())))
+                map!(v, x, y => Some(Constant::Bool(x.to_num().unwrap() >= y.to_num().unwrap())))
             }
             Pred::Eq([x, y]) => {
                 map!(v, x, y => {
                     match (x,y) {
                         (Constant::Bool(x), Constant::Bool(y)) => Some(Constant::Bool(x == y)),
-                        (Constant::Int(x), Constant::Int(y)) => Some(Constant::Bool(x == y)),
+                        (Constant::Num(x), Constant::Num(y)) => Some(Constant::Bool(x == y)),
                         _ => panic!("Cannot compare Bool and Int: {} {}", x, y)
                     }
                 })
@@ -176,7 +178,7 @@ impl SynthLanguage for Pred {
                 map!(v, x, y => {
                     match (x,y) {
                         (Constant::Bool(x), Constant::Bool(y)) => Some(Constant::Bool(x != y)),
-                        (Constant::Int(x), Constant::Int(y)) => Some(Constant::Bool(x != y)),
+                        (Constant::Num(x), Constant::Num(y)) => Some(Constant::Bool(x != y)),
                         _ => panic!("Cannot compare Bool and Int: {} {}", x, y)
                     }
                 })
@@ -193,13 +195,13 @@ impl SynthLanguage for Pred {
             }
 
             Pred::BVar(_) => vec![],
-            Pred::IVar(_) => vec![],
+            Pred::NVar(_) => vec![],
         }
     }
 
     fn to_var(&self) -> Option<Symbol> {
         match self {
-            Pred::BVar(BVar(sym)) | Pred::IVar(IVar(sym)) => Some(*sym),
+            Pred::BVar(BVar(sym)) | Pred::NVar(NVar(sym)) => Some(*sym),
             _ => None,
         }
     }
@@ -207,8 +209,8 @@ impl SynthLanguage for Pred {
     fn mk_var(sym: egg::Symbol) -> Self {
         if sym.as_str().starts_with('b') {
             Pred::BVar(BVar(sym))
-        } else if sym.as_str().starts_with('i') {
-            Pred::IVar(IVar(sym))
+        } else if sym.as_str().starts_with('n') {
+            Pred::NVar(NVar(sym))
         } else {
             panic!("invalid variable: {}", sym)
         }
@@ -223,24 +225,31 @@ impl SynthLanguage for Pred {
     }
 
     fn init_synth(synth: &mut Synthesizer<Self>) {
+        let cvec_len = 300;
         let mut egraph: EGraph<Pred, SynthAnalysis> = EGraph::new(SynthAnalysis {
-            cvec_len: 10,
-            constant_fold: ConstantFoldMethod::NoFold,
+            cvec_len: cvec_len,
+            constant_fold: ConstantFoldMethod::CvecMatching,
             rule_lifting: false,
         });
 
         for i in 0..synth.params.variables {
             let rng = &mut synth.rng;
-            let mut i_vals = vec![];
+
+            let mut samples = vec![];
+            samples.append(&mut sampler(rng, 8, 6, cvec_len / 3));
+            samples.append(&mut sampler(rng, 6, 8, cvec_len / 3));
+            samples.append(&mut sampler(rng, 4, 1, cvec_len / 3));
+            samples.shuffle(rng);
+
+            let n_vals: Vec<Option<Constant>> = samples.iter().map(|x| Some(x.clone())).collect();
             let mut b_vals = vec![];
-            let i_id = egraph.add(Pred::IVar(IVar(Symbol::from("i".to_owned() + letter(i)))));
+            let n_id = egraph.add(Pred::NVar(NVar(Symbol::from("n".to_owned() + letter(i)))));
             let b_id = egraph.add(Pred::BVar(BVar(Symbol::from("b".to_owned() + letter(i)))));
             for _ in 0..10 {
-                i_vals.push(Some(Constant::Int(rng.gen::<usize>())));
                 b_vals.push(Some(Constant::Bool(rng.gen::<bool>())));
             }
 
-            egraph[i_id].data.cvec = i_vals.clone();
+            egraph[n_id].data.cvec = n_vals.clone();
             egraph[b_id].data.cvec = b_vals.clone();
         }
 
@@ -268,9 +277,14 @@ impl SynthLanguage for Pred {
         }
 
         for cvec in env.values_mut() {
-            cvec.reserve(n);
-            for s in sampler(&mut synth.rng, n) {
-                cvec.push(Some(s));
+            cvec.reserve(n * 3);
+            let mut vals = vec![];
+            vals.append(&mut sampler(&mut synth.rng, 8, 6, n));
+            vals.append(&mut sampler(&mut synth.rng, 6, 8, n));
+            vals.append(&mut sampler(&mut synth.rng, 3, 1, n));
+            vals.shuffle(&mut synth.rng);
+            for v in vals {
+                cvec.push(Some(v));
             }
         }
 
@@ -280,15 +294,23 @@ impl SynthLanguage for Pred {
     }
 }
 
-pub fn sampler(rng: &mut Pcg64, num_samples: usize) -> Vec<Constant> {
+pub fn gen_pos(rng: &mut Pcg64, bits: u64) -> BigInt {
+    let mut res: BigInt;
+    loop {
+        res = BigInt::from_biguint(Sign::Plus, rng.gen_biguint(bits));
+        if res != 0.to_bigint().unwrap() {
+            break;
+        }
+    }
+    res
+}
+
+pub fn sampler(rng: &mut Pcg64, num: u64, denom: u64, num_samples: usize) -> Vec<Constant> {
     let mut ret = vec![];
     for _ in 0..num_samples {
-        let flip = rng.gen::<bool>();
-        if flip {
-            ret.push(Constant::Int(rng.gen::<usize>() % 10));
-        } else {
-            ret.push(Constant::Int(rng.gen::<usize>()));
-        }
+        let num = gen_pos(rng, num);
+        let denom = gen_pos(rng, denom);
+        ret.push(Constant::Num(Ratio::new(num, denom)));
     }
     ret
 }


### PR DESCRIPTION
This is necessary to add the math operators to the language without having to deal with overflow