### PR TITLE
Fix String domain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ z3 = "0.10.0"
 rustc-hash = "1"
 symbolic_expressions = "5"
 rayon = "1"
-smallvec = { version = "1.6", features = ["union", "const_generics"] }
+smallstr = "0.3"
 
 [dependencies.egg]
 version = "0.8"

--- a/src/bin/str.rs
+++ b/src/bin/str.rs
@@ -5,44 +5,61 @@ Experimental String domain.
 use egg::*;
 use ruler::*;
 
-use std::ops::*;
-
-use smallvec::SmallVec;
 use std::fmt;
 
-pub type SmallStr = SmallVec<[u8; 24]>;
+use rand::{seq::SliceRandom, Rng};
+use rand_pcg::Pcg64;
+use smallstr::SmallString;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SVar(egg::Symbol);
+impl fmt::Display for SVar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "s")
+    }
+}
+impl std::str::FromStr for SVar {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('s') {
+            Ok(SVar(Symbol::from(s)))
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NVar(egg::Symbol);
+impl fmt::Display for NVar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "n")
+    }
+}
+impl std::str::FromStr for NVar {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('n') {
+            Ok(NVar(Symbol::from(s)))
+        } else {
+            Err(())
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-/// Two types of Constants: Num and Str.
 pub enum Constant {
     Num(i64),
-    Str(SmallStr),
+    Str(SmallString<[u8; 24]>),
 }
-
-impl Constant {
-    fn to_num(&self) -> Option<i64> {
-        match self {
-            Constant::Num(n) => Some(*n),
-            Constant::Str(_) => None,
-        }
-    }
-    fn to_slice(&self) -> Option<&[u8]> {
-        match self {
-            Constant::Num(_) => None,
-            Constant::Str(s) => Some(s.as_slice()),
-        }
-    }
-    fn to_str(&self) -> Option<&str> {
-        self.to_slice()
-            .map(|bytes| unsafe { std::str::from_utf8_unchecked(bytes) })
-    }
-}
-
 impl fmt::Display for Constant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Constant::Num(n) => n.fmt(f),
             Constant::Str(s) => {
-                let s = std::str::from_utf8(s).unwrap();
+                let s = s.as_str();
                 write!(f, "\"")?;
                 s.fmt(f)?;
                 write!(f, "\"")
@@ -54,30 +71,56 @@ impl fmt::Display for Constant {
 impl std::str::FromStr for Constant {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match i64::from_str(s) {
-            Ok(i) => Ok(Self::Num(i)),
-            Err(_) => {
-                let s = s.trim_matches('"');
-                Ok(Self::Str(s.as_bytes().into()))
-            }
+        if let Ok(i) = i64::from_str(s) {
+            Ok(Self::Num(i))
+        } else {
+            Ok(Self::Str(SmallString::from_str(s.trim_matches('"'))))
+        }
+    }
+}
+
+impl Constant {
+    fn to_smallstr(&self) -> Option<SmallString<[u8; 24]>> {
+        match self {
+            Constant::Str(s) => Some(s.clone()),
+            Constant::Num(_) => None,
+        }
+    }
+
+    fn to_str(&self) -> Option<&str> {
+        match self {
+            Constant::Str(s) => Some(s.as_str()),
+            Constant::Num(_) => None,
+        }
+    }
+
+    fn to_num(&self) -> Option<i64> {
+        match self {
+            Constant::Num(n) => Some(*n),
+            Constant::Str(_) => None,
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Type {
-    Top,
+    String,
+    Number,
 }
-
-impl std::fmt::Display for Type {
+impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "")
+        match self {
+            Type::String => write!(f, "s"),
+            Type::Number => write!(f, "n"),
+        }
     }
 }
 
 define_language! {
     /// Defines operators for Strings.
     pub enum Lang {
+        SVar(SVar),
+        NVar(NVar),
         "str.++" = Concat([Id; 2]),
         "str.replace" = Replace([Id; 3]),
         "str.at" = At([Id; 2]),
@@ -89,13 +132,7 @@ define_language! {
         "+" = Add([Id; 2]),
         "-" = Sub([Id; 2]),
         Lit(Constant),
-        Var(egg::Symbol),
     }
-}
-
-/// Concatenate strings.
-fn concat(a: &[u8], b: &[u8]) -> SmallStr {
-    a.iter().chain(b).copied().collect()
 }
 
 impl SynthLanguage for Lang {
@@ -103,7 +140,24 @@ impl SynthLanguage for Lang {
     type Type = Type;
 
     fn get_type(&self) -> Self::Type {
-        Type::Top
+        match self {
+            Lang::Lit(c) => match c {
+                Constant::Num(_) => Type::Number,
+                Constant::Str(_) => Type::String,
+            },
+            Lang::SVar(_)
+            | Lang::Concat(_)
+            | Lang::Replace(_)
+            | Lang::At(_)
+            | Lang::SubStr(_)
+            | Lang::FromInt(_) => Type::String,
+            Lang::NVar(_)
+            | Lang::Len(_)
+            | Lang::ToInt(_)
+            | Lang::IndexOf(_)
+            | Lang::Add(_)
+            | Lang::Sub(_) => Type::Number,
+        }
     }
 
     fn eval<'a, F>(&'a self, cvec_len: usize, mut v: F) -> CVec<Self>
@@ -111,66 +165,59 @@ impl SynthLanguage for Lang {
         F: FnMut(&'a Id) -> &'a CVec<Self>,
     {
         match self {
-            Lang::Concat([a, b]) => map!(v, a, b => {
-                let a = a.to_slice().unwrap();
-                let b = b.to_slice().unwrap();
-                Some(Constant::Str(concat(a, b)))
-            }),
+            Lang::SVar(_) => vec![],
+            Lang::NVar(_) => vec![],
+            Lang::Lit(c) => vec![Some(c.clone()); cvec_len],
+            Lang::Concat([a, b]) => {
+                map!(v, a, b => Some(Constant::Str(SmallString::from_str(&format!("{}{}", a.to_str().unwrap(), b.to_str().unwrap())))))
+            }
             Lang::Replace([s, t, t2]) => map!(v, s, t, t2 => {
                 let s = s.to_str().unwrap();
                 let t = t.to_str().unwrap();
                 let t2 = t2.to_str().unwrap();
                 let out = s.replacen(t, t2, 1);
-                Some(Constant::Str(out.into_bytes().into()))
+                Some(Constant::Str(SmallString::from_str(&out)))
             }),
             Lang::At([a, i]) => map!(v, a, i => {
-                let a = a.to_slice().unwrap();
+                let a = a.to_smallstr().unwrap();
                 let i = i.to_num().unwrap();
-                if 0 <= i && i < (a.len() as _) {
-                    let i = i as usize;
-                    Some(Constant::Str(a[i..i+1].into()))
+                if i < 0 || i > (a.len() as _) {
+                    Some(Constant::Str(SmallString::default()))
                 } else {
-                    Some(Constant::Str(SmallStr::default()))
+                    let i = i as usize;
+                    Some(Constant::Str(SmallString::from(a.get(i..i+1).unwrap_or(""))))
                 }
             }),
             Lang::SubStr([a, i, len]) => map!(v, a, i, len => {
-                let a = a.to_slice().unwrap();
-                let n = a.len() as i64;
-                let i = i.to_num().unwrap();
-                let len = len.to_num().unwrap();
-                if 0 <= i && i < n && len > 0 {
-                    let j = (i + len).min(n) as usize;
-                    let i = i as usize;
-                    Some(Constant::Str(a[i..j].into()))
-                } else {
-                    Some(Constant::Str(SmallStr::default()))
+                let a = a.to_smallstr().unwrap();
+                let n = a.len() as usize;
+                let i = i.to_num().unwrap() as usize;
+                let len = len.to_num().unwrap() as usize;
+                let j = (i + len).min(n) as usize;
+                match a.get(i..j) {
+                    Some(s) => Some(Constant::Str(SmallString::from(s))),
+                    None => Some(Constant::Str(SmallString::default()))
                 }
             }),
             Lang::FromInt(i) => map!(v, i => {
                 let i = i.to_num().unwrap();
-                Some(Constant::Str(i.to_string().into_bytes().into()))
+                Some(Constant::Str(SmallString::from(i.to_string())))
             }),
             Lang::ToInt(s) => map!(v, s => {
                 let s = s.to_str().unwrap();
                 let i = s.parse::<i64>().unwrap_or(-1);
                 Some(Constant::Num(i))
             }),
-            Lang::Len(s) => map!(v, s => {
-                let s = s.to_str().unwrap();
-                Some(Constant::Num(s.len() as _))
-            }),
+            Lang::Len(s) => {
+                map!(v, s => Some(Constant::Num(s.to_smallstr().unwrap().len() as i64)))
+            }
             Lang::IndexOf([s, t, i]) => map!(v, s, t, i => {
                 let s = s.to_str().unwrap();
                 let t = t.to_str().unwrap();
-                let i = i.to_num().unwrap();
-                if 0 <= i && i <= (s.len() as _) {
-                    let i = i as usize;
-                    match s[i..].find(t) {
-                        None => Some(Constant::Num(-1)),
-                        Some(j) => Some(Constant::Num(j as _))
-                    }
-                } else {
-                    Some(Constant::Num(-1))
+                let i = i.to_num().unwrap() as usize;
+                match s.get(i..s.len()).unwrap_or("").find(t) {
+                    Some(j) => Some(Constant::Num(j as _)),
+                    None => Some(Constant::Num(-1))
                 }
             }),
             Lang::Add([i, j]) => map!(v, i, j => {
@@ -183,21 +230,25 @@ impl SynthLanguage for Lang {
                 let j = j.to_num().unwrap();
                 Some(Constant::Num(i.checked_sub(j).unwrap()))
             }),
-            Lang::Lit(n) => vec![Some(n.clone()); cvec_len],
-            Lang::Var(_) => vec![],
         }
     }
 
     fn to_var(&self) -> Option<Symbol> {
-        if let Lang::Var(sym) = self {
-            Some(*sym)
-        } else {
-            None
+        match self {
+            Lang::SVar(SVar(sym)) => Some(*sym),
+            Lang::NVar(NVar(sym)) => Some(*sym),
+            _ => None,
         }
     }
 
-    fn mk_var(sym: Symbol) -> Self {
-        Lang::Var(sym)
+    fn mk_var(sym: egg::Symbol) -> Self {
+        if sym.as_str().starts_with('s') {
+            Lang::SVar(SVar(sym))
+        } else if sym.as_str().starts_with('n') {
+            Lang::NVar(NVar(sym))
+        } else {
+            panic!("invalid variable: {}", sym)
+        }
     }
 
     fn is_constant(&self) -> bool {
@@ -209,30 +260,14 @@ impl SynthLanguage for Lang {
     }
 
     fn init_synth(synth: &mut Synthesizer<Self>) {
-        let mut str_consts: Vec<SmallStr> = vec![SmallStr::new()];
-        for _ in 0..3 {
-            let mut new = vec![SmallStr::new()];
-            for s in &str_consts {
-                let mut s = s.clone();
-                s.push(b'A');
-                new.push(s.clone());
-                s.pop();
-                s.push(b'B');
-                new.push(s)
-            }
-            str_consts = new
-        }
-        str_consts.push(b"1".iter().copied().collect());
-        str_consts.push(b"-1000".iter().copied().collect());
-
-        let str_consts: Vec<Option<Constant>> = str_consts
+        let strs = vec![
+            "A", "B", "AA", "AB", "BA", "BB", "AAA", "AAB", "ABA", "ABB", "BAA", "BAB", "BBA",
+            "BBA",
+        ];
+        let str_consts: Vec<Option<Constant>> = strs
             .into_iter()
-            .map(|s| Some(Constant::Str(s)))
+            .map(|s| Some(Constant::Str(SmallString::from_str(s))))
             .collect();
-
-        for s in &str_consts {
-            println!("const: {}", s.as_ref().unwrap());
-        }
 
         let int_consts = vec![
             Some(Constant::Num(-1)),
@@ -240,12 +275,11 @@ impl SynthLanguage for Lang {
             Some(Constant::Num(1)),
             Some(Constant::Num(1000)),
         ];
-        let int_consts = self_product(&int_consts, synth.params.str_int_variables);
 
         let str_consts = self_product(&str_consts, synth.params.variables);
+        let int_consts = self_product(&int_consts, synth.params.variables);
 
         let cvec_len = str_consts[0].len();
-        println!("cvec_len: {}", cvec_len);
         let mut egraph = EGraph::new(SynthAnalysis {
             cvec_len,
             constant_fold: if synth.params.no_constant_fold {
@@ -259,23 +293,17 @@ impl SynthLanguage for Lang {
         egraph.add(Lang::Lit(Constant::Num(-1)));
         egraph.add(Lang::Lit(Constant::Num(0)));
         egraph.add(Lang::Lit(Constant::Num(1)));
-        // egraph.add(Lang::Lit("\"A\"".parse().unwrap()));
-        // egraph.add(Lang::Lit("\"B\"".parse().unwrap()));
-        egraph.add(Lang::Lit(Constant::Str(Default::default())));
 
-        for (i, item) in str_consts.iter().enumerate().take(synth.params.variables) {
-            let var = Symbol::from(letter(i));
-            let id = egraph.add(Lang::Var(var));
-            egraph[id].data.cvec = item.clone();
-        }
-        for (i, item) in int_consts
-            .iter()
-            .enumerate()
-            .take(synth.params.str_int_variables)
-        {
-            let int_var = Symbol::from(letter(i + synth.params.variables));
-            let id = egraph.add(Lang::Var(int_var));
-            egraph[id].data.cvec = item.iter().cycle().take(cvec_len).cloned().collect();
+        for i in 0..synth.params.variables {
+            let s_id = egraph.add(Lang::SVar(SVar(Symbol::from("s".to_owned() + letter(i)))));
+            let n_id = egraph.add(Lang::NVar(NVar(Symbol::from("n".to_owned() + letter(i)))));
+            egraph[s_id].data.cvec = str_consts[i].clone();
+            egraph[n_id].data.cvec = int_consts[i]
+                .iter()
+                .cycle()
+                .take(cvec_len)
+                .cloned()
+                .collect();
         }
 
         synth.egraph = egraph;
@@ -290,14 +318,8 @@ impl SynthLanguage for Lang {
             .map(|id| (id, extract.find_best_cost(id)))
             .collect();
 
-        let is_str = |&id: &Id| -> bool {
-            match synth.egraph[id].data.cvec[0] {
-                Some(Constant::Num(_)) => false,
-                Some(Constant::Str(_)) => true,
-                None => panic!(),
-            }
-        };
-        let is_num = |id: &Id| !is_str(id);
+        let is_str = |&id: &Id| -> bool { synth.egraph[id].data.class_type == Type::String };
+        let is_num = |&id: &Id| -> bool { synth.egraph[id].data.class_type == Type::Number };
 
         let mut to_add = vec![];
         for a in synth.ids().filter(is_str) {
@@ -350,12 +372,68 @@ impl SynthLanguage for Lang {
     }
 
     fn validate(
-        _synth: &mut Synthesizer<Self>,
-        _lhs: &Pattern<Self>,
-        _rhs: &Pattern<Self>,
+        synth: &mut Synthesizer<Self>,
+        lhs: &Pattern<Self>,
+        rhs: &Pattern<Self>,
     ) -> ValidationResult {
-        ValidationResult::Valid
+        let n = synth.params.num_fuzz;
+        let mut env: HashMap<Var, Vec<Option<Constant>>> = HashMap::default();
+
+        for var in lhs.vars() {
+            env.insert(var, vec![]);
+        }
+
+        for var in rhs.vars() {
+            env.insert(var, vec![]);
+        }
+
+        for (var, cvec) in env.iter_mut() {
+            cvec.reserve(n);
+            let additional = if var.to_string().starts_with("?s") {
+                str_sampler(&mut synth.rng, n)
+            } else if var.to_string().starts_with("?n") {
+                int_sampler(&mut synth.rng, n)
+            } else {
+                vec![]
+            };
+
+            for s in additional {
+                cvec.push(Some(s));
+            }
+        }
+
+        let lvec = Self::eval_pattern(lhs, &env, n);
+        let rvec = Self::eval_pattern(rhs, &env, n);
+        ValidationResult::from(lvec == rvec)
     }
+}
+
+pub fn str_sampler(rng: &mut Pcg64, num_samples: usize) -> Vec<Constant> {
+    let mut ret = vec![];
+    let letters = vec!["a", "b", "c", "d", "e"];
+    for _ in 0..num_samples {
+        let len = rng.gen::<usize>() % 10;
+        let mut s = SmallString::default();
+        for _ in 0..len {
+            s.push_str(letters.choose(rng).unwrap());
+        }
+        ret.push(Constant::Str(s));
+    }
+    ret
+}
+
+pub fn int_sampler(rng: &mut Pcg64, num_samples: usize) -> Vec<Constant> {
+    let mut ret = vec![];
+    for _ in 0..num_samples {
+        let flip = rng.gen::<bool>();
+        if flip {
+            ret.push(Constant::Num(rng.gen::<i64>() % 10));
+        } else {
+            // generate i32s so they can be added or subtracted without overflow
+            ret.push(Constant::Num(rng.gen::<i32>().into()));
+        }
+    }
+    ret
 }
 
 /// Entry point.

--- a/src/bin/str.rs
+++ b/src/bin/str.rs
@@ -80,13 +80,6 @@ impl std::str::FromStr for Constant {
 }
 
 impl Constant {
-    fn to_smallstr(&self) -> Option<SmallString<[u8; 24]>> {
-        match self {
-            Constant::Str(s) => Some(s.clone()),
-            Constant::Num(_) => None,
-        }
-    }
-
     fn to_str(&self) -> Option<&str> {
         match self {
             Constant::Str(s) => Some(s.as_str()),
@@ -179,7 +172,7 @@ impl SynthLanguage for Lang {
                 Some(Constant::Str(SmallString::from_str(&out)))
             }),
             Lang::At([a, i]) => map!(v, a, i => {
-                let a = a.to_smallstr().unwrap();
+                let a = a.to_str().unwrap();
                 let i = i.to_num().unwrap();
                 if i < 0 || i > (a.len() as _) {
                     Some(Constant::Str(SmallString::default()))
@@ -189,7 +182,7 @@ impl SynthLanguage for Lang {
                 }
             }),
             Lang::SubStr([a, i, len]) => map!(v, a, i, len => {
-                let a = a.to_smallstr().unwrap();
+                let a = a.to_str().unwrap();
                 let n = a.len() as usize;
                 let i = i.to_num().unwrap() as usize;
                 let len = len.to_num().unwrap() as usize;
@@ -209,7 +202,7 @@ impl SynthLanguage for Lang {
                 Some(Constant::Num(i))
             }),
             Lang::Len(s) => {
-                map!(v, s => Some(Constant::Num(s.to_smallstr().unwrap().len() as i64)))
+                map!(v, s => Some(Constant::Num(s.to_str().unwrap().len() as i64)))
             }
             Lang::IndexOf([s, t, i]) => map!(v, s, t, i => {
                 let s = s.to_str().unwrap();

--- a/src/bin/str.rs
+++ b/src/bin/str.rs
@@ -174,7 +174,7 @@ impl SynthLanguage for Lang {
             Lang::At([a, i]) => map!(v, a, i => {
                 let a = a.to_str().unwrap();
                 let i = i.to_num().unwrap();
-                if i < 0 || i > (a.len() as _) {
+                if i < 0 || i >= (a.len() as _) {
                     Some(Constant::Str(SmallString::default()))
                 } else {
                     let i = i as usize;


### PR DESCRIPTION
String was broken on `main`.
I tried to root-cause the issue for a bit but couldn't quite tell what was going on.
Instead, I re-implemented it, and used it as an opportunity to switch from `SmallVec<u8>` to `SmallString`. I also added fuzzing for rule validation, which was at least part of the problem.

Here are the rules I find with [this recipe](https://github.com/uwplse/recipes/blob/str2/str/str.spec)
```
(+ ?nb ?na) <=> (+ ?na ?nb)
(str.replace ?sb ?sa ?sa) => ?sb
(str.replace ?sb ?sb ?sa) => ?sa
(str.replace ?sb "" ?sa) <=> (str.++ ?sa ?sb)
(str.indexof ?sb "" ?na) => (- ?na ?na)
(str.substr ?sb ?na 1) <=> (str.at ?sb ?na)
(str.substr "" ?nb ?na) => ""
(str.substr ?sb ?na 0) => ""
(str.indexof "" ?sb ?na) => (str.indexof ?sb ?sb 1)
(str.to_int ?sa) => -1
?na <=> (- ?na 0)
(- ?na ?na) => 0
?na <=> (+ 0 ?na)
(str.indexof ?sa ?sa 0) => 0
(str.replace "" ?sa "") => ""
(str.substr "a" ?na ?na) => ""
(str.substr "a" 1 ?na) => ""
(str.replace "" "a" ?sa) => ""
(str.indexof ?sa ?sa 1) <=> (str.indexof "a" ?sa 1)
```

And here are the enumerate (iter 1) rules:
```
(+ ?nb ?na) <=> (+ ?na ?nb)
(str.replace ?sb ?sb ?sa) => ?sa
(str.replace ?sb ?sa ?sa) => ?sb
(str.substr ?sb ?na 1) <=> (str.at ?sb ?na)
(str.substr ?sb ?na 0) => (str.at ?sb -1)
(str.substr ?sb -1 ?na) => (str.at ?sb -1)
(str.indexof ?sb ?sa -1) => (str.indexof ?sa ?sa -1)
(str.to_int ?sa) => -1
?na <=> (- ?na 0)
?na <=> (+ 0 ?na)
(- ?na ?na) => 0
(- ?na 1) <=> (+ -1 ?na)
(- ?na -1) <=> (+ 1 ?na)
(str.indexof ?sa ?sa 0) => 0
?sa <=> (str.substr ?sa 0 -1)
(str.indexof ?sa ?sa 1) <=> (str.indexof ?sa ?sa -1)
(str.substr ?sa 1 -1) <=> (str.at ?sa -1)
```