### PR TITLE
Add math ops to pred lang

### DIFF
--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -70,6 +70,9 @@ define_language! {
     "&" = And([Id;2]),
     "|" = Or([Id;2]),
     "^" = Xor([Id;2]),
+    "+" = Add([Id; 2]),
+    "-" = Sub([Id; 2]),
+    "*" = Mul([Id; 2]),
   }
 }
 
@@ -142,7 +145,7 @@ impl SynthLanguage for Pred {
                 Constant::Bool(_) => Type::Bool,
                 Constant::Num(_) => Type::Num,
             },
-            Pred::NVar(_) => Type::Num,
+            Pred::NVar(_) | Pred::Add(_) | Pred::Sub(_) | Pred::Mul(_) => Type::Num,
             _ => Type::Bool,
         }
     }
@@ -192,6 +195,15 @@ impl SynthLanguage for Pred {
             }
             Pred::Xor([x, y]) => {
                 map!(v, x, y => Some(Constant::Bool(x.to_bool().unwrap() ^ y.to_bool().unwrap())))
+            }
+            Pred::Add([x, y]) => {
+                map!(v, x, y => Some(Constant::Num(x.to_num().unwrap() + y.to_num().unwrap())))
+            }
+            Pred::Sub([x, y]) => {
+                map!(v, x, y => Some(Constant::Num(x.to_num().unwrap() - y.to_num().unwrap())))
+            }
+            Pred::Mul([x, y]) => {
+                map!(v, x, y => Some(Constant::Num(x.to_num().unwrap() * y.to_num().unwrap())))
             }
 
             Pred::BVar(_) => vec![],


### PR DESCRIPTION
Nothing really interesting here- just adding math ops to the language

```
(- ?nc (- ?nb ?na)) ==> (- ?na (- ?nb ?nc))
(- (- ?nc ?nb) ?na) ==> (- (- ?nc ?na) ?nb)
(* ?nc (* ?nb ?na)) <=> (* ?nb (* ?na ?nc))
(+ ?nc (+ ?nb ?na)) <=> (+ ?nb (+ ?na ?nc))
(- (+ ?nc ?nb) ?na) <=> (+ ?nb (- ?nc ?na))
(- ?nc (- ?nb ?na)) <=> (- (+ ?nc ?na) ?nb)
(- ?nc (+ ?nb ?na)) <=> (- (- ?nc ?nb) ?na)
(* ?nb ?na) ==> (* ?na ?nb)
(+ ?nb ?na) ==> (+ ?na ?nb)
(+ ?nb (- ?na ?na)) ==> ?nb
(* ?nb (- ?na ?na)) ==> (- ?nb ?nb)
(* ?nb (+ ?na ?na)) ==> (* ?na (+ ?nb ?nb))
(- ?nb (+ ?nb ?na)) ==> (- (- ?na ?na) ?na)
(* ?na 0) ==> 0
(- ?na 0) <=> (* ?na 1)
(+ ?na 0) <=> (* ?na 1)
(- ?na 1) <=> (+ ?na -1)
(- ?na -1) <=> (+ ?na 1)
(- 0 ?na) <=> (* ?na -1)
```