### PR TITLE
Pred verify

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,7 +3,7 @@ rational = ["run", "--quiet", "--release", "--bin", "rational", "--", "synth", "
 float =    ["run", "--quiet", "--release", "--bin", "float",    "--", "synth", "--num-fuzz", "1000000"]
 bool =     ["run", "--quiet", "--release", "--bin", "bool",     "--", "synth", "--no-conditionals"]
 str =      ["run", "--quiet", "--release", "--bin", "str",      "--", "synth", "--no-conditionals"]
-pred =     ["run", "--quiet", "--release", "--bin", "pred",     "--", "synth", "--no-conditionals", "--use-smt"]
+pred =     ["run", "--quiet", "--release", "--bin", "pred",     "--", "synth", "--no-conditionals", "--use-smt", "--important-cvec-offsets", "2"]
 
 bv4 =      ["run", "--quiet", "--release", "--bin", "bv4",  "--", "synth", "--complete-cvec", "--no-conditionals"]
 bv4c1 =    ["run", "--quiet", "--release", "--bin", "bv4",  "--", "synth", "--complete-cvec", "--no-conditionals", "--no-constants-above-iter=1"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -3,7 +3,7 @@ rational = ["run", "--quiet", "--release", "--bin", "rational", "--", "synth", "
 float =    ["run", "--quiet", "--release", "--bin", "float",    "--", "synth", "--num-fuzz", "1000000"]
 bool =     ["run", "--quiet", "--release", "--bin", "bool",     "--", "synth", "--no-conditionals"]
 str =      ["run", "--quiet", "--release", "--bin", "str",      "--", "synth", "--no-conditionals"]
-
+pred =     ["run", "--quiet", "--release", "--bin", "pred",     "--", "synth", "--no-conditionals", "--use-smt"]
 
 bv4 =      ["run", "--quiet", "--release", "--bin", "bv4",  "--", "synth", "--complete-cvec", "--no-conditionals"]
 bv4c1 =    ["run", "--quiet", "--release", "--bin", "bv4",  "--", "synth", "--complete-cvec", "--no-conditionals", "--no-constants-above-iter=1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ float-cmp = "0.8.0"
 lazy_static = "1.4.0"
 itertools = "0.9.0"
 # fixed = "1.9.0"
-#z3 = "0.10.0"
-z3 = {version = "0.10.0", features = ["static-link-z3"]}
+z3 = "0.10.0"
+#z3 = {version = "0.10.0", features = ["static-link-z3"]}
 rustc-hash = "1"
 symbolic_expressions = "5"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ float-cmp = "0.8.0"
 lazy_static = "1.4.0"
 itertools = "0.9.0"
 # fixed = "1.9.0"
-z3 = "0.10.0"
-#z3 = {version = "0.10.0", features = ["static-link-z3"]}
+#z3 = "0.10.0"
+z3 = {version = "0.10.0", features = ["static-link-z3"]}
 rustc-hash = "1"
 symbolic_expressions = "5"
 rayon = "1"

--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -5,11 +5,11 @@ use std::{
 };
 
 use egg::*;
-use num::{rational::Ratio, Zero};
 use num::{
     bigint::{BigInt, RandBigInt, Sign, ToBigInt},
     ToPrimitive,
 };
+use num::{rational::Ratio, Zero};
 use rand::{seq::SliceRandom, Rng};
 use rand_pcg::Pcg64;
 use ruler::*;
@@ -238,18 +238,17 @@ impl SynthLanguage for Pred {
     }
 
     fn init_synth(synth: &mut Synthesizer<Self>) {
-
         let rng = &mut synth.rng;
         let mut consts: Vec<Option<Constant>> = vec![];
 
         for i in 0..synth.params.important_cvec_offsets {
             consts.push(mk_constant(
                 &i.to_bigint().unwrap(),
-                &((i as u32).to_bigint().unwrap()),
+                &((1_u32).to_bigint().unwrap()),
             ));
             consts.push(mk_constant(
                 &(-i.to_bigint().unwrap()),
-                &((1 as u32).to_bigint().unwrap()),
+                &((1_u32).to_bigint().unwrap()),
             ));
         }
 
@@ -307,7 +306,7 @@ impl SynthLanguage for Pred {
                 SatResult::Sat => {
                     println!("z3 validation: failed for {} => {}", lhs, rhs);
                     ValidationResult::Invalid
-                },
+                }
                 SatResult::Unknown => {
                     synth.smt_unknown += 1;
                     ValidationResult::Unknown

--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -266,7 +266,9 @@ impl SynthLanguage for Pred {
             let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
             let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
             match (lexpr, rexpr) {
-                (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => solver.assert(&z3::ast::Bool::not(&lb._eq(&rb))),
+                (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => {
+                    solver.assert(&z3::ast::Bool::not(&lb._eq(&rb)))
+                }
                 (Z3::Z3Int(li), Z3::Z3Int(ri)) => solver.assert(&z3::ast::Bool::not(&li._eq(&ri))),
                 _ => return ValidationResult::Invalid,
             };
@@ -352,22 +354,22 @@ fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Pred]) -> Z3<'a> {
             Pred::Lt([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
                 let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
-                buf.push(Z3::Z3Bool(z3::ast::Int::lt(&lexpr, &rexpr)))
+                buf.push(Z3::Z3Bool(z3::ast::Int::lt(lexpr, rexpr)))
             }
             Pred::Leq([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
                 let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
-                buf.push(Z3::Z3Bool(z3::ast::Int::le(&lexpr, &rexpr)))
+                buf.push(Z3::Z3Bool(z3::ast::Int::le(lexpr, rexpr)))
             }
             Pred::Gt([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
                 let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
-                buf.push(Z3::Z3Bool(z3::ast::Int::gt(&lexpr, &rexpr)))
+                buf.push(Z3::Z3Bool(z3::ast::Int::gt(lexpr, rexpr)))
             }
             Pred::Geq([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
                 let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
-                buf.push(Z3::Z3Bool(z3::ast::Int::ge(&lexpr, &rexpr)))
+                buf.push(Z3::Z3Bool(z3::ast::Int::ge(lexpr, rexpr)))
             }
             Pred::Eq([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].clone();
@@ -392,9 +394,9 @@ fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Pred]) -> Z3<'a> {
                     (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => {
                         buf.push(Z3::Z3Bool(z3::ast::Bool::not(&z3::ast::Bool::_eq(lb, rb))))
                     }
-                    (Z3::Z3Int(li), Z3::Z3Int(ri)) => {
-                        buf.push(Z3::Z3Bool(z3::ast::Bool::not(&z3::ast::Int::_eq(li, ri).not())))
-                    }
+                    (Z3::Z3Int(li), Z3::Z3Int(ri)) => buf.push(Z3::Z3Bool(z3::ast::Bool::not(
+                        &z3::ast::Int::_eq(li, ri).not(),
+                    ))),
                     (Z3::Z3Bool(_), Z3::Z3Int(_)) | (Z3::Z3Int(_), Z3::Z3Bool(_)) => panic!(
                         "Rule candidate seems to have different 
                     type of lhs and rhs."
@@ -408,17 +410,17 @@ fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Pred]) -> Z3<'a> {
             Pred::And([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].get_z3bool().unwrap();
                 let rexpr = &buf[usize::from(*b)].get_z3bool().unwrap();
-                buf.push(Z3::Z3Bool(z3::ast::Bool::and(ctx, &[&lexpr, &rexpr])))
+                buf.push(Z3::Z3Bool(z3::ast::Bool::and(ctx, &[lexpr, rexpr])))
             }
             Pred::Or([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].get_z3bool().unwrap();
                 let rexpr = &buf[usize::from(*b)].get_z3bool().unwrap();
-                buf.push(Z3::Z3Bool(z3::ast::Bool::or(ctx, &[&lexpr, &rexpr])))
+                buf.push(Z3::Z3Bool(z3::ast::Bool::or(ctx, &[lexpr, rexpr])))
             }
             Pred::Xor([a, b]) => {
                 let lexpr = &buf[usize::from(*a)].get_z3bool().unwrap();
                 let rexpr = &buf[usize::from(*b)].get_z3bool().unwrap();
-                buf.push(Z3::Z3Bool(z3::ast::Bool::xor(&lexpr, &rexpr)))
+                buf.push(Z3::Z3Bool(z3::ast::Bool::xor(lexpr, rexpr)))
             }
         }
     }

--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -277,8 +277,8 @@ impl SynthLanguage for Pred {
             let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
             let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
             match (lexpr, rexpr) {
-                (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => solver.assert(&lb._eq(&rb).not()),
-                (Z3::Z3Real(ln), Z3::Z3Real(rn)) => solver.assert(&ln._eq(&rn).not()),
+                (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => solver.assert(&z3::ast::Bool::not(&lb._eq(&rb))),
+                (Z3::Z3Real(ln), Z3::Z3Real(rn)) => solver.assert(&z3::ast::Bool::not(&ln._eq(&rn))),
                 _ => return ValidationResult::Invalid,
             };
             match solver.check() {
@@ -430,7 +430,7 @@ fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Pred]) -> Z3<'a> {
                     (Z3::Z3Real(ln), Z3::Z3Real(rn)) => {
                         buf.push(Z3::Z3Bool(z3::ast::Bool::not(&z3::ast::Real::_eq(ln, rn))))
                     }
-                    (Z3::Z3Bool(_), Z3::Z3Real(_)) | (Z3::Z3Real(_), Z3::Z3Bool(_)) => panic!(
+                    _ => panic!(
                         "Rule candidate seems to have different 
                     type of lhs and rhs."
                     ),

--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{self, Display},
     hash::Hash,
+    ops::Not,
     str::FromStr,
 };
 
@@ -8,6 +9,7 @@ use egg::*;
 use rand::Rng;
 use rand_pcg::Pcg64;
 use ruler::*;
+use z3::{ast::Ast, SatResult};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 
@@ -58,9 +60,9 @@ define_language! {
     Lit(Constant),
     BVar(BVar),
     IVar(IVar),
-    "<" = Le([Id;2]),
+    "<" = Lt([Id;2]),
     "<=" = Leq([Id;2]),
-    ">" = Ge([Id;2]),
+    ">" = Gt([Id;2]),
     ">=" = Geq([Id;2]),
     "==" = Eq([Id;2]),
     "!=" = Neq([Id;2]),
@@ -74,7 +76,7 @@ define_language! {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Constant {
     Bool(bool),
-    Int(usize),
+    Int(i64),
 }
 
 impl fmt::Display for Constant {
@@ -89,7 +91,7 @@ impl fmt::Display for Constant {
 impl std::str::FromStr for Constant {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(i) = usize::from_str(s) {
+        if let Ok(i) = i64::from_str(s) {
             Ok(Self::Int(i))
         } else if let Ok(b) = bool::from_str(s) {
             Ok(Self::Bool(b))
@@ -100,7 +102,7 @@ impl std::str::FromStr for Constant {
 }
 
 impl Constant {
-    fn to_int(&self) -> Option<usize> {
+    fn to_int(&self) -> Option<i64> {
         match self {
             Constant::Int(n) => Some(*n),
             Constant::Bool(_) => None,
@@ -151,13 +153,13 @@ impl SynthLanguage for Pred {
     {
         match self {
             Pred::Lit(c) => vec![Some(c.clone()); cvec_len],
-            Pred::Le([x, y]) => {
+            Pred::Lt([x, y]) => {
                 map!(v, x, y => Some(Constant::Bool(x.to_int().unwrap() < y.to_int().unwrap())))
             }
             Pred::Leq([x, y]) => {
                 map!(v, x, y => Some(Constant::Bool(x.to_int().unwrap() <= y.to_int().unwrap())))
             }
-            Pred::Ge([x, y]) => {
+            Pred::Gt([x, y]) => {
                 map!(v, x, y => Some(Constant::Bool(x.to_int().unwrap() > y.to_int().unwrap())))
             }
             Pred::Geq([x, y]) => {
@@ -236,7 +238,7 @@ impl SynthLanguage for Pred {
             let i_id = egraph.add(Pred::IVar(IVar(Symbol::from("i".to_owned() + letter(i)))));
             let b_id = egraph.add(Pred::BVar(BVar(Symbol::from("b".to_owned() + letter(i)))));
             for _ in 0..10 {
-                i_vals.push(Some(Constant::Int(rng.gen::<usize>())));
+                i_vals.push(Some(Constant::Int(rng.gen::<i64>())));
                 b_vals.push(Some(Constant::Bool(rng.gen::<bool>())));
             }
 
@@ -256,27 +258,49 @@ impl SynthLanguage for Pred {
         lhs: &Pattern<Self>,
         rhs: &Pattern<Self>,
     ) -> ValidationResult {
-        let n = synth.params.num_fuzz;
-        let mut env = HashMap::default();
-
-        for var in lhs.vars() {
-            env.insert(var, vec![]);
-        }
-
-        for var in rhs.vars() {
-            env.insert(var, vec![]);
-        }
-
-        for cvec in env.values_mut() {
-            cvec.reserve(n);
-            for s in sampler(&mut synth.rng, n) {
-                cvec.push(Some(s));
+        if synth.params.use_smt {
+            let mut cfg = z3::Config::new();
+            cfg.set_timeout_msec(1000);
+            let ctx = z3::Context::new(&cfg);
+            let solver = z3::Solver::new(&ctx);
+            let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
+            let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
+            match (lexpr, rexpr) {
+                (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => solver.assert(&z3::ast::Bool::not(&lb._eq(&rb))),
+                (Z3::Z3Int(li), Z3::Z3Int(ri)) => solver.assert(&z3::ast::Bool::not(&li._eq(&ri))),
+                _ => return ValidationResult::Invalid,
+            };
+            match solver.check() {
+                SatResult::Unsat => ValidationResult::Valid,
+                SatResult::Sat => ValidationResult::Invalid,
+                SatResult::Unknown => {
+                    synth.smt_unknown += 1;
+                    ValidationResult::Unknown
+                }
             }
-        }
+        } else {
+            let n = synth.params.num_fuzz;
+            let mut env = HashMap::default();
 
-        let lvec = Self::eval_pattern(lhs, &env, n);
-        let rvec = Self::eval_pattern(rhs, &env, n);
-        ValidationResult::from(lvec == rvec)
+            for var in lhs.vars() {
+                env.insert(var, vec![]);
+            }
+
+            for var in rhs.vars() {
+                env.insert(var, vec![]);
+            }
+
+            for cvec in env.values_mut() {
+                cvec.reserve(n);
+                for s in sampler(&mut synth.rng, n) {
+                    cvec.push(Some(s));
+                }
+            }
+
+            let lvec = Self::eval_pattern(lhs, &env, n);
+            let rvec = Self::eval_pattern(rhs, &env, n);
+            ValidationResult::from(lvec == rvec)
+        }
     }
 }
 
@@ -285,12 +309,120 @@ pub fn sampler(rng: &mut Pcg64, num_samples: usize) -> Vec<Constant> {
     for _ in 0..num_samples {
         let flip = rng.gen::<bool>();
         if flip {
-            ret.push(Constant::Int(rng.gen::<usize>() % 10));
+            ret.push(Constant::Int(rng.gen::<i64>() % 10));
         } else {
-            ret.push(Constant::Int(rng.gen::<usize>()));
+            ret.push(Constant::Int(rng.gen::<i64>()));
         }
     }
     ret
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Z3<'a> {
+    Z3Bool(z3::ast::Bool<'a>),
+    Z3Int(z3::ast::Int<'a>),
+}
+
+impl<'a> Z3<'a> {
+    fn get_z3bool(&self) -> Option<z3::ast::Bool<'a>> {
+        match self {
+            Z3::Z3Bool(b) => Some(b.clone()),
+            Z3::Z3Int(_) => None,
+        }
+    }
+
+    fn get_z3int(&self) -> Option<z3::ast::Int<'a>> {
+        match self {
+            Z3::Z3Bool(_) => None,
+            Z3::Z3Int(i) => Some(i.clone()),
+        }
+    }
+}
+
+fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Pred]) -> Z3<'a> {
+    let mut buf: Vec<Z3> = vec![];
+    for node in expr.as_ref().iter() {
+        match node {
+            Pred::Lit(lit) => match lit {
+                Constant::Bool(b) => buf.push(Z3::Z3Bool(z3::ast::Bool::from_bool(ctx, *b))),
+                Constant::Int(i) => buf.push(Z3::Z3Int(z3::ast::Int::from_i64(ctx, *i))),
+            },
+            Pred::BVar(bv) => buf.push(Z3::Z3Bool(z3::ast::Bool::new_const(ctx, bv.to_string()))),
+            Pred::IVar(iv) => buf.push(Z3::Z3Int(z3::ast::Int::new_const(ctx, iv.to_string()))),
+            Pred::Lt([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
+                let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Int::lt(&lexpr, &rexpr)))
+            }
+            Pred::Leq([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
+                let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Int::le(&lexpr, &rexpr)))
+            }
+            Pred::Gt([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
+                let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Int::gt(&lexpr, &rexpr)))
+            }
+            Pred::Geq([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].get_z3int().unwrap();
+                let rexpr = &buf[usize::from(*b)].get_z3int().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Int::ge(&lexpr, &rexpr)))
+            }
+            Pred::Eq([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].clone();
+                let rexpr = &buf[usize::from(*b)].clone();
+                match (lexpr, rexpr) {
+                    (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => {
+                        buf.push(Z3::Z3Bool(z3::ast::Bool::_eq(lb, rb)))
+                    }
+                    (Z3::Z3Int(li), Z3::Z3Int(ri)) => {
+                        buf.push(Z3::Z3Bool(z3::ast::Int::_eq(li, ri)))
+                    }
+                    (Z3::Z3Bool(_), Z3::Z3Int(_)) | (Z3::Z3Int(_), Z3::Z3Bool(_)) => panic!(
+                        "Rule candidate seems to have different 
+                    type of lhs and rhs."
+                    ),
+                }
+            }
+            Pred::Neq([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].clone();
+                let rexpr = &buf[usize::from(*b)].clone();
+                match (lexpr, rexpr) {
+                    (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => {
+                        buf.push(Z3::Z3Bool(z3::ast::Bool::not(&z3::ast::Bool::_eq(lb, rb))))
+                    }
+                    (Z3::Z3Int(li), Z3::Z3Int(ri)) => {
+                        buf.push(Z3::Z3Bool(z3::ast::Bool::not(&z3::ast::Int::_eq(li, ri).not())))
+                    }
+                    (Z3::Z3Bool(_), Z3::Z3Int(_)) | (Z3::Z3Int(_), Z3::Z3Bool(_)) => panic!(
+                        "Rule candidate seems to have different 
+                    type of lhs and rhs."
+                    ),
+                }
+            }
+            Pred::Not(a) => {
+                let lexpr = &buf[usize::from(*a)].get_z3bool().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Bool::not(lexpr)))
+            }
+            Pred::And([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].get_z3bool().unwrap();
+                let rexpr = &buf[usize::from(*b)].get_z3bool().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Bool::and(ctx, &[&lexpr, &rexpr])))
+            }
+            Pred::Or([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].get_z3bool().unwrap();
+                let rexpr = &buf[usize::from(*b)].get_z3bool().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Bool::or(ctx, &[&lexpr, &rexpr])))
+            }
+            Pred::Xor([a, b]) => {
+                let lexpr = &buf[usize::from(*a)].get_z3bool().unwrap();
+                let rexpr = &buf[usize::from(*b)].get_z3bool().unwrap();
+                buf.push(Z3::Z3Bool(z3::ast::Bool::xor(&lexpr, &rexpr)))
+            }
+        }
+    }
+    buf.pop().unwrap()
 }
 
 fn main() {

--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -277,12 +277,8 @@ impl SynthLanguage for Pred {
             let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
             let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
             match (lexpr, rexpr) {
-                (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => {
-                    solver.assert(&lb._eq(&rb).not())
-                }
-                (Z3::Z3Real(ln), Z3::Z3Real(rn)) => {
-                    solver.assert(&ln._eq(&rn).not())
-                }
+                (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => solver.assert(&lb._eq(&rb).not()),
+                (Z3::Z3Real(ln), Z3::Z3Real(rn)) => solver.assert(&ln._eq(&rn).not()),
                 _ => return ValidationResult::Invalid,
             };
             match solver.check() {
@@ -428,12 +424,12 @@ fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Pred]) -> Z3<'a> {
                 let lexpr = &buf[usize::from(*a)].clone();
                 let rexpr = &buf[usize::from(*b)].clone();
                 match (lexpr, rexpr) {
-                    (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => buf.push(Z3::Z3Bool(z3::ast::Bool::not(
-                        &z3::ast::Bool::_eq(lb, rb)
-                    ))),
-                    (Z3::Z3Real(ln), Z3::Z3Real(rn)) => buf.push(Z3::Z3Bool(z3::ast::Bool::not(
-                        &z3::ast::Real::_eq(ln, rn),
-                    ))),
+                    (Z3::Z3Bool(lb), Z3::Z3Bool(rb)) => {
+                        buf.push(Z3::Z3Bool(z3::ast::Bool::not(&z3::ast::Bool::_eq(lb, rb))))
+                    }
+                    (Z3::Z3Real(ln), Z3::Z3Real(rn)) => {
+                        buf.push(Z3::Z3Bool(z3::ast::Bool::not(&z3::ast::Real::_eq(ln, rn))))
+                    }
                     (Z3::Z3Bool(_), Z3::Z3Real(_)) | (Z3::Z3Real(_), Z3::Z3Bool(_)) => panic!(
                         "Rule candidate seems to have different 
                     type of lhs and rhs."

--- a/src/bin/rational.rs
+++ b/src/bin/rational.rs
@@ -45,15 +45,6 @@ define_language! {
     }
 }
 
-/// Return a non-zero constant.
-fn mk_constant(n: &BigInt, d: &BigInt) -> Option<Constant> {
-    if d.is_zero() {
-        None
-    } else {
-        Some(Ratio::new(n.clone(), d.clone()))
-    }
-}
-
 fn sign(interval: &Interval<Constant>) -> Sign {
     match (&interval.low, &interval.high) {
         (None, None) => Sign::ContainsZero,
@@ -310,14 +301,14 @@ impl SynthLanguage for Math {
         let mut consts: Vec<Option<Constant>> = vec![];
 
         for i in 0..synth.params.important_cvec_offsets {
-            consts.push(mk_constant(
+            consts.push(Some(mk_constant(
                 &i.to_bigint().unwrap(),
                 &(1.to_bigint().unwrap()),
-            ));
-            consts.push(mk_constant(
+            )));
+            consts.push(Some(mk_constant(
                 &(-i.to_bigint().unwrap()),
                 &(1.to_bigint().unwrap()),
-            ));
+            )));
         }
 
         consts.sort();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use num::{rational::Ratio, BigInt, Zero};
+
 /// Helper function to cross product a list of values `ts` across `n` variables.
 pub fn self_product<T: Clone>(ts: &[T], n: usize) -> Vec<Vec<T>> {
     (0..n)
@@ -21,6 +23,15 @@ pub fn self_product<T: Clone>(ts: &[T], n: usize) -> Vec<Vec<T>> {
 // Hack from https://www.reddit.com/r/rust/comments/bk7v15/my_next_favourite_way_to_divide_integers_rounding/
 pub fn div_up(a: usize, b: usize) -> usize {
     (0..a).step_by(b).size_hint().0
+}
+
+// Make a Ratio whose denominator is not zero.
+pub fn mk_constant(n: &BigInt, d: &BigInt) -> Ratio<BigInt> {
+    if d.is_zero() {
+        panic!("mk_constant: denominator is zero!")
+    } else {
+        Ratio::new(n.clone(), d.clone())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR has the following changes:

- using z3 to validate rules
- using the important-cvec-offset approach for initializing cvecs for `NVar`, similar to the rational domain.
- `le -> lt`, `ge -> gt`
- an entry for `pred` in the config