### PR TITLE
Add Nat and Pos domains

### DIFF
--- a/src/bin/bigint.rs
+++ b/src/bin/bigint.rs
@@ -82,7 +82,7 @@ impl SynthLanguage for Math {
         matches!(self, Math::Num(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/bool.rs
+++ b/src/bin/bool.rs
@@ -169,7 +169,7 @@ impl SynthLanguage for Math {
         matches!(self, Math::Lit(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Lit(c)
     }
 

--- a/src/bin/bv-bool.rs
+++ b/src/bin/bv-bool.rs
@@ -101,7 +101,7 @@ impl SynthLanguage for Math {
         matches!(self, Math::Num(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/complex-real.rs
+++ b/src/bin/complex-real.rs
@@ -367,7 +367,7 @@ impl SynthLanguage for Math {
         Math::Var(Variable(sym))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::ComplexConst(c)
     }
 

--- a/src/bin/float.rs
+++ b/src/bin/float.rs
@@ -115,7 +115,7 @@ impl SynthLanguage for Math {
         matches!(self, Math::Num(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/nat.rs
+++ b/src/bin/nat.rs
@@ -120,16 +120,13 @@ impl SynthLanguage for Nat {
     }
 
     fn is_constant(&self) -> bool {
-        match self {
-            Nat::Z => true,
-            _ => false,
-        }
+        matches!(self, Nat::Z)
     }
 
     fn init_synth(synth: &mut Synthesizer<Self>) {
         let cvec_len = 10;
         let mut egraph: EGraph<Nat, SynthAnalysis> = EGraph::new(SynthAnalysis {
-            cvec_len: cvec_len,
+            cvec_len,
             constant_fold: ConstantFoldMethod::IntervalAnalysis,
             rule_lifting: false,
         });

--- a/src/bin/nat.rs
+++ b/src/bin/nat.rs
@@ -1,5 +1,6 @@
 use egg::*;
-use ruler::*;
+use rand::Rng;
+use ruler::{HashMap, *};
 
 define_language! {
     pub enum Nat {
@@ -13,7 +14,7 @@ define_language! {
 
 impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
+        write!(f, "")
     }
 }
 
@@ -22,43 +23,131 @@ pub enum Type {
     Nat,
 }
 
+impl Nat {
+    fn mk_constant_id(c: usize, egraph: &mut EGraph<Self, SynthAnalysis>) -> Id {
+        match c {
+            0 => egraph.add(Nat::Z),
+            _ => {
+                let pred = Self::mk_constant_id(c - 1, egraph);
+                egraph.add(Nat::S(pred))
+            }
+        }
+    }
+}
+
 impl SynthLanguage for Nat {
     type Constant = usize;
 
     type Type = Type;
 
     fn get_type(&self) -> Self::Type {
-        todo!()
+        Type::Nat
     }
 
-    fn eval<'a, F>(&'a self, cvec_len: usize, f: F) -> CVec<Self>
+    fn eval<'a, F>(&'a self, cvec_len: usize, mut v: F) -> CVec<Self>
     where
         F: FnMut(&'a Id) -> &'a CVec<Self>,
     {
-        todo!()
+        match self {
+            Nat::Z => vec![Some(0); cvec_len],
+            Nat::S(x) => map!(v, x => Some(*x + 1)),
+            Nat::Add([a, b]) => map!(v, a, b => Some(*a + *b)),
+            Nat::Mul([a, b]) => map!(v, a, b => Some(*a * *b)),
+            Nat::Var(_) => vec![],
+        }
+    }
+
+    fn mk_interval(&self, egraph: &EGraph<Self, SynthAnalysis>) -> Interval<Self::Constant> {
+        match self {
+            Nat::Z => Interval::new(Some(0), Some(0)),
+            Nat::S(x) => {
+                let x_int = egraph[*x].data.interval.clone();
+                if let Some(l) = x_int.low {
+                    Interval::new(Some(l + 1), x_int.high.map(|v| v + 1))
+                } else {
+                    panic!("There shouldn't be infinite lower bounds for Nat")
+                }
+            }
+            Nat::Add([x, y]) => {
+                let x_int = egraph[*x].data.interval.clone();
+                let y_int = egraph[*y].data.interval.clone();
+
+                let low = x_int
+                    .low
+                    .zip(y_int.low)
+                    .map(|(a, b)| a + b)
+                    .expect("There shouldn't be infinite lower bounds for Nat");
+
+                let high = x_int.high.zip(y_int.high).map(|(a, b)| a + b);
+
+                Interval::new(Some(low), high)
+            }
+            Nat::Mul([x, y]) => {
+                let x_int = egraph[*x].data.interval.clone();
+                let y_int = egraph[*y].data.interval.clone();
+
+                let low = x_int
+                    .low
+                    .zip(y_int.low)
+                    .map(|(a, b)| a * b)
+                    .expect("There shouldn't be infinite lower bounds for Nat");
+
+                let high = x_int.high.zip(y_int.high).map(|(a, b)| a * b);
+
+                Interval::new(Some(low), high)
+            }
+            Nat::Var(_) => Interval::new(Some(0), None),
+        }
     }
 
     fn to_var(&self) -> Option<Symbol> {
-        todo!()
+        if let Nat::Var(sym) = self {
+            Some(*sym)
+        } else {
+            None
+        }
     }
 
     fn mk_var(sym: egg::Symbol) -> Self {
-        todo!()
+        Nat::Var(sym)
     }
 
-        todo!()
-    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
+    fn mk_constant(c: Self::Constant, egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
+        match c {
+            0 => Nat::Z,
+            _ => Nat::S(Self::mk_constant_id(c - 1, egraph)),
+        }
     }
 
     fn is_constant(&self) -> bool {
-        todo!()
+        match self {
+            Nat::Z => true,
+            _ => false,
+        }
     }
 
     fn init_synth(synth: &mut Synthesizer<Self>) {
-        todo!()
+        let cvec_len = 10;
+        let mut egraph: EGraph<Nat, SynthAnalysis> = EGraph::new(SynthAnalysis {
+            cvec_len: cvec_len,
+            constant_fold: ConstantFoldMethod::IntervalAnalysis,
+            rule_lifting: false,
+        });
+
+        for i in 0..synth.params.variables {
+            let var = Symbol::from(letter(i));
+            let id = egraph.add(Nat::Var(var));
+            let mut vals = vec![];
+            for _ in 0..cvec_len {
+                vals.push(Some(synth.rng.gen::<usize>()));
+            }
+            egraph[id].data.cvec = vals.clone();
+        }
+
+        synth.egraph = egraph;
     }
 
-    fn make_layer(synth: &Synthesizer<Self>, iter: usize) -> Vec<Self> {
+    fn make_layer(_synth: &Synthesizer<Self>, _iter: usize) -> Vec<Self> {
         todo!()
     }
 
@@ -67,7 +156,28 @@ impl SynthLanguage for Nat {
         lhs: &Pattern<Self>,
         rhs: &Pattern<Self>,
     ) -> ValidationResult {
-        todo!()
+        let n = synth.params.num_fuzz;
+        let mut env = HashMap::default();
+        for var in lhs.vars() {
+            env.insert(var, vec![]);
+        }
+        for var in rhs.vars() {
+            env.insert(var, vec![]);
+        }
+
+        for cvec in env.values_mut() {
+            cvec.reserve(n);
+            let mut vals = vec![];
+            for _ in 0..n {
+                vals.push(synth.rng.gen::<usize>());
+            }
+            for v in vals {
+                cvec.push(Some(v));
+            }
+        }
+        let lvec = Self::eval_pattern(lhs, &env, n);
+        let rvec = Self::eval_pattern(rhs, &env, n);
+        ValidationResult::from(lvec == rvec)
     }
 }
 

--- a/src/bin/nat.rs
+++ b/src/bin/nat.rs
@@ -46,8 +46,8 @@ impl SynthLanguage for Nat {
         todo!()
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
         todo!()
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
     }
 
     fn is_constant(&self) -> bool {

--- a/src/bin/nat.rs
+++ b/src/bin/nat.rs
@@ -1,0 +1,76 @@
+use egg::*;
+use ruler::*;
+
+define_language! {
+    pub enum Nat {
+        "Z" = Z,
+        "S" = S(Id),
+        "+" = Add([Id; 2]),
+        "*" = Mul([Id; 2]),
+        Var(egg::Symbol),
+    }
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Type {
+    Nat,
+}
+
+impl SynthLanguage for Nat {
+    type Constant = usize;
+
+    type Type = Type;
+
+    fn get_type(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn eval<'a, F>(&'a self, cvec_len: usize, f: F) -> CVec<Self>
+    where
+        F: FnMut(&'a Id) -> &'a CVec<Self>,
+    {
+        todo!()
+    }
+
+    fn to_var(&self) -> Option<Symbol> {
+        todo!()
+    }
+
+    fn mk_var(sym: egg::Symbol) -> Self {
+        todo!()
+    }
+
+    fn mk_constant(c: Self::Constant) -> Self {
+        todo!()
+    }
+
+    fn is_constant(&self) -> bool {
+        todo!()
+    }
+
+    fn init_synth(synth: &mut Synthesizer<Self>) {
+        todo!()
+    }
+
+    fn make_layer(synth: &Synthesizer<Self>, iter: usize) -> Vec<Self> {
+        todo!()
+    }
+
+    fn validate(
+        synth: &mut Synthesizer<Self>,
+        lhs: &Pattern<Self>,
+        rhs: &Pattern<Self>,
+    ) -> ValidationResult {
+        todo!()
+    }
+}
+
+fn main() {
+    Nat::main()
+}

--- a/src/bin/pos.rs
+++ b/src/bin/pos.rs
@@ -86,10 +86,7 @@ impl SynthLanguage for Pos {
     }
 
     fn is_constant(&self) -> bool {
-        match self {
-            Pos::Z | Pos::XH => true,
-            _ => false,
-        }
+        matches!(self, Pos::Z | Pos::XH)
     }
 
     fn init_synth(synth: &mut Synthesizer<Self>) {

--- a/src/bin/pos.rs
+++ b/src/bin/pos.rs
@@ -1,0 +1,84 @@
+use egg::*;
+use ruler::*;
+
+define_language! {
+    pub enum Pos {
+        // Nat
+        "Z" = Z,
+        "S" = S(Id),
+
+        // Pos
+        "XH" = XH,
+        "XO" = XO(Id),
+        "XI" = XI(Id),
+
+        "+" = Add([Id; 2]),
+        "*" = Mul([Id; 2]),
+
+        Var(egg::Symbol),
+    }
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Type {
+    Pos,
+}
+
+impl SynthLanguage for Pos {
+    type Constant = usize;
+
+    type Type = Type;
+
+    fn get_type(&self) -> Self::Type {
+        todo!()
+    }
+
+    fn eval<'a, F>(&'a self, cvec_len: usize, f: F) -> CVec<Self>
+    where
+        F: FnMut(&'a Id) -> &'a CVec<Self>,
+    {
+        todo!()
+    }
+
+    fn to_var(&self) -> Option<Symbol> {
+        todo!()
+    }
+
+    fn mk_var(sym: egg::Symbol) -> Self {
+        todo!()
+    }
+
+    fn mk_constant(c: Self::Constant, egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
+        todo!()
+    }
+
+    fn is_constant(&self) -> bool {
+        todo!()
+    }
+
+    fn init_synth(synth: &mut Synthesizer<Self>) {
+        todo!()
+    }
+
+    fn make_layer(synth: &Synthesizer<Self>, iter: usize) -> Vec<Self> {
+        todo!()
+    }
+
+    fn validate(
+        synth: &mut Synthesizer<Self>,
+        lhs: &Pattern<Self>,
+        rhs: &Pattern<Self>,
+    ) -> ValidationResult {
+        todo!()
+    }
+}
+
+fn main() {
+    Pos::main()
+}

--- a/src/bin/pos.rs
+++ b/src/bin/pos.rs
@@ -1,3 +1,11 @@
+/**
+ * Pos is a datatype representing the strictly positive integers in a binary way.
+ * XH represents 1
+ * XO and XI represent adding a new least significant digit
+ * That is, (XO n) represents 2n and (XI n) represents 2n + 1
+ * Example: 6 is represented as (XO (XI XH))
+ * See https://coq.inria.fr/library/Coq.Numbers.BinNums.html
+ */
 use egg::*;
 use ruler::*;
 

--- a/src/bin/pred.rs
+++ b/src/bin/pred.rs
@@ -240,7 +240,7 @@ impl SynthLanguage for Pred {
         matches!(self, Pred::Lit(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Pred::Lit(c)
     }
 

--- a/src/bin/rational-new-div.rs
+++ b/src/bin/rational-new-div.rs
@@ -125,7 +125,7 @@ impl SynthLanguage for Math {
         matches!(self, Math::Num(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/rational.rs
+++ b/src/bin/rational.rs
@@ -278,7 +278,7 @@ impl SynthLanguage for Math {
         matches!(self, Math::Num(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Num(c)
     }
 

--- a/src/bin/real-rat.rs
+++ b/src/bin/real-rat.rs
@@ -240,7 +240,7 @@ impl SynthLanguage for Math {
         Math::Var(Variable(sym))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::Rat(c)
     }
 

--- a/src/bin/str.rs
+++ b/src/bin/str.rs
@@ -248,7 +248,7 @@ impl SynthLanguage for Lang {
         matches!(self, Lang::Lit(_))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Lang::Lit(c)
     }
 

--- a/src/bin/trig.rs
+++ b/src/bin/trig.rs
@@ -210,7 +210,7 @@ impl SynthLanguage for Math {
         Math::Var(Variable::from(sym.as_str()))
     }
 
-    fn mk_constant(c: Self::Constant) -> Self {
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
         Math::RealConst(c)
     }
 
@@ -618,7 +618,7 @@ impl SynthLanguage for Math {
                     if let Some(v) = extract_constant(&egraph[*i].nodes) {
                         if let Ok(x) = real_to_rational(&v) {
                             let r = Real::from((-x).to_string());
-                            to_add = Some(Self::mk_constant(r));
+                            to_add = Some(Self::mk_constant(r, egraph));
                             break;
                         }
                     }
@@ -629,7 +629,7 @@ impl SynthLanguage for Math {
                             if let Ok(x) = real_to_rational(&v) {
                                 if let Ok(y) = real_to_rational(&w) {
                                     let r = Real::from((x + y).to_string());
-                                    to_add = Some(Self::mk_constant(r));
+                                    to_add = Some(Self::mk_constant(r, egraph));
                                     break;
                                 }
                             }
@@ -642,7 +642,7 @@ impl SynthLanguage for Math {
                             if let Ok(x) = real_to_rational(&v) {
                                 if let Ok(y) = real_to_rational(&w) {
                                     let r = Real::from((x - y).to_string());
-                                    to_add = Some(Self::mk_constant(r));
+                                    to_add = Some(Self::mk_constant(r, egraph));
                                     break;
                                 }
                             }
@@ -655,7 +655,7 @@ impl SynthLanguage for Math {
                             if let Ok(x) = real_to_rational(&v) {
                                 if let Ok(y) = real_to_rational(&w) {
                                     let r = Real::from((x * y).to_string());
-                                    to_add = Some(Self::mk_constant(r));
+                                    to_add = Some(Self::mk_constant(r, egraph));
                                     break;
                                 }
                             }
@@ -669,7 +669,7 @@ impl SynthLanguage for Math {
                                 if let Ok(y) = real_to_rational(&w) {
                                     if !y.is_zero() {
                                         let r = Real::from((x / y).to_string());
-                                        to_add = Some(Self::mk_constant(r));
+                                        to_add = Some(Self::mk_constant(r, egraph));
                                         break;
                                     }
                                 }
@@ -686,7 +686,10 @@ impl SynthLanguage for Math {
             if let Math::RealConst(n) = v {
                 if let Ok(x) = real_to_rational(&n) {
                     if x.is_negative() {
-                        let pos_id = egraph.add(Self::mk_constant(Real::from((-x).to_string())));
+                        let pos_id = egraph.add(Self::mk_constant(
+                            Real::from((-x).to_string()),
+                            &mut egraph.clone(),
+                        ));
                         let neg_id = egraph.add(Math::Neg(pos_id));
                         egraph.union(neg_id, id);
                     }

--- a/src/bv.rs
+++ b/src/bv.rs
@@ -232,7 +232,7 @@ macro_rules! impl_bv {
                 matches!(self, Math::Num(_))
             }
 
-            fn mk_constant(c: Self::Constant) -> Self {
+            fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
                 Math::Num(c)
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,11 @@ pub trait SynthLanguage: egg::Language + Send + Sync + Display + FromOp + 'stati
         PatternAst::from(nodes).into()
     }
 
+    /**
+     * Most domains don't need a reference to the egraph to make a constant node.
+     * However, Pos and Nat represent numbers recursively, so adding a new constant
+     * requires adding multiple nodes to the egraph.
+     */
     fn mk_constant(c: Self::Constant, egraph: &mut EGraph<Self, SynthAnalysis>) -> Self;
     fn is_constant(&self) -> bool;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub trait SynthLanguage: egg::Language + Send + Sync + Display + FromOp + 'stati
         PatternAst::from(nodes).into()
     }
 
-    fn mk_constant(c: Self::Constant) -> Self;
+    fn mk_constant(c: Self::Constant, egraph: &mut EGraph<Self, SynthAnalysis>) -> Self;
     fn is_constant(&self) -> bool;
 
     /// Generalize a pattern
@@ -1581,7 +1581,7 @@ impl<L: SynthLanguage> egg::Analysis<L> for SynthAnalysis {
                 if sig.exact {
                     let first = sig.cvec.iter().find_map(|x| x.as_ref());
                     if let Some(first) = first {
-                        let enode = L::mk_constant(first.clone());
+                        let enode = L::mk_constant(first.clone(), egraph);
                         let added = egraph.add(enode);
                         egraph.union(id, added);
                     }
@@ -1595,7 +1595,7 @@ impl<L: SynthLanguage> egg::Analysis<L> for SynthAnalysis {
                 } = interval
                 {
                     if a == b {
-                        let enode = L::mk_constant(a.clone());
+                        let enode = L::mk_constant(a.clone(), egraph);
                         let added = egraph.add(enode);
                         egraph.union(id, added);
                     }


### PR DESCRIPTION
```
Nat :=
| Z       // 0
| (S n)   // n + 1
```
Nat is implemented as a standard ruler domain. Nothing super interesting here.
Example rules:
```
(* ?c (* ?b ?a)) ==> (* ?a (* ?b ?c))
(+ ?c (+ ?b ?a)) ==> (+ ?a (+ ?b ?c))
(* ?b ?a) ==> (* ?a ?b)
(+ ?b ?a) ==> (+ ?a ?b)
(+ ?b (S ?a)) ==> (+ ?a (S ?b))
(S (+ ?b ?a)) <=> (+ ?a (S ?b))
(+ ?a (* ?b ?a)) <=> (* ?a (S ?b))
?a <=> (+ ?a Z)
?a <=> (* ?a (S Z))
(* ?a Z) ==> Z
```

```
Pos :=
| XH       // 1
| (XI n)   // 2n + 1
| (XO n)   // 2n
```
Pos is implemented with rule lifting from Nat. The denotation rewrites are
```
XH <=> (S Z)
(XO ?a) <=> (+ ?a ?a)
(XI ?a) <=> (+ ?a (+ ?a (S Z)))
```
Example rules:
```
(XO ?a) <=> (+ ?a ?a)
?a <=> (* XH ?a)
(XI ?a) <=> (+ XH (XO ?a))
(XO (XI ?a)) <=> (+ XH (XI (XO ?a)))
(XO (XO (XO XH))) <=> (+ XH (XI (XI XH)))
(+ XH (XI (+ ?b ?a))) <=> (+ (XI ?b) (XI ?a))
(XO (XO (XI ?a))) <=> (+ XH (XI (XI (XO ?a))))
(XO (+ (XO XH) ?a)) <=> (+ (XI XH) (XI ?a))
(XO (XO (XO (XO XH)))) <=> (+ XH (XI (XI (XI XH))))
(XO (+ ?b (XI ?a))) <=> (+ (XI ?b) (XI (XO ?a)))
(XI (+ ?b (+ XH ?a))) <=> (+ (XI ?b) (+ (XI ?a) XH))
(+ XH (* ?a (XI (XO XH)))) <=> (+ ?a (XI (XO ?a)))
(XO (+ ?a (XO (XO XH)))) <=> (+ (XI ?a) (XI (XI XH)))
```
