### PR TITLE
[Bug fix] Return empty vec if lhs & rhs are already unioned

### DIFF
--- a/src/bin/complex-real.rs
+++ b/src/bin/complex-real.rs
@@ -271,7 +271,7 @@ fn is_real_zero(n: &Math) -> bool {
 
 fn symbol_to_rational(r: &Real) -> Result<Rational, ParseRatioError> {
     let s = r.as_str();
-    (&s[..(s.len() - 1)]).parse()
+    (s[..(s.len() - 1)]).parse()
 }
 
 fn fold_real_neg(v: &Real) -> Option<Real> {

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -132,6 +132,9 @@ impl<L: SynthLanguage> Applier<L, SynthAnalysis> for NotUndefined<L> {
         }
 
         let id = apply_pat(self.rhs.ast.as_ref(), egraph, subst);
+        if id == matched_id {
+            return vec![];
+        }
 
         if !egraph[id].data.is_defined() {
             return vec![];


### PR DESCRIPTION
This was preventing egg from ever saturating!
Basically, we need to return an empty vec if applying the rewrite didn't actually "do anything"
See https://github.com/egraphs-good/egg/blob/main/src/run.rs#L560 and https://github.com/egraphs-good/egg/blob/main/src/run.rs#L589 for how this ends up getting used. 