### PR TITLE
Simplify loop

### DIFF
--- a/src/derive.rs
+++ b/src/derive.rs
@@ -108,6 +108,12 @@ pub fn derive<L: SynthLanguage>(params: DeriveParams) {
                 break;
             }
         }
+        // One more sat
+        runner = mk_runner(runner.egraph, &l, &r)
+            .with_node_limit(usize::MAX)
+            .with_time_limit(Duration::from_secs(30))
+            .with_iter_limit(100)
+            .run(&sat);
         l_id = runner.egraph.find(runner.roots[0]);
         r_id = runner.egraph.find(runner.roots[1]);
         if l_id == r_id {

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -185,16 +185,18 @@ impl<L: SynthLanguage> Synthesizer<L> {
 
         let mut candidates = EqualityMap::default();
         let extract = Extractor::new(&self.egraph, AstSize);
+
         for ids in by_cvec.values() {
-            let mut terms_ids: Vec<_> = ids.iter().map(|&id| (extract.find_best(id), id)).collect();
-            terms_ids.sort_by_key(|x| x.0 .0); // sort by cost
-            let ((_, e1), _) = terms_ids.remove(0);
-            for ((_, e2), _) in terms_ids {
-                if let Some(eq) = Equality::new(&e1, &e2) {
-                    candidates.insert(eq.name.clone(), eq);
-                }
-                if let Some(eq) = Equality::new(&e2, &e1) {
-                    candidates.insert(eq.name.clone(), eq);
+            let exprs: Vec<_> = ids.iter().map(|&id| extract.find_best(id).1).collect();
+
+            for (idx, e1) in exprs.iter().enumerate() {
+                for e2 in exprs[(idx + 1)..].iter() {
+                    if let Some(eq) = Equality::new(&e1, &e2) {
+                        candidates.insert(eq.name.clone(), eq);
+                    }
+                    if let Some(eq) = Equality::new(&e2, &e1) {
+                        candidates.insert(eq.name.clone(), eq);
+                    }
                 }
             }
         }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -191,10 +191,10 @@ impl<L: SynthLanguage> Synthesizer<L> {
 
             for (idx, e1) in exprs.iter().enumerate() {
                 for e2 in exprs[(idx + 1)..].iter() {
-                    if let Some(eq) = Equality::new(&e1, &e2) {
+                    if let Some(eq) = Equality::new(e1, e2) {
                         candidates.insert(eq.name.clone(), eq);
                     }
-                    if let Some(eq) = Equality::new(&e2, &e1) {
+                    if let Some(eq) = Equality::new(e2, e1) {
                         candidates.insert(eq.name.clone(), eq);
                     }
                 }


### PR DESCRIPTION
This shouldn't change anything functionally, it's just a more readable version of the loop

Two things:
1. We don't use the cost or the id, so we should just have a vector of the `RecExpr`s, not the tuples in `terms_ids`
2. We want to loop over the [upper triangular matrix](https://en.wikipedia.org/wiki/Triangular_matrix). The old way did this by removing the first element before the inner loop (`let ((_, e1), _) = terms_ids.remove(0);`). I think it's much more readable to structure the nested loop as
```
for i in 0..len {
  for j in i..len {
    // do something
  }
}
```