### PR TITLE
Don't let time limit be configurable

### DIFF
--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -148,7 +148,7 @@ impl<L: SynthLanguage> Ruleset<L> {
             .with_scheduler(egg::SimpleScheduler)
             .with_node_limit(limits.node)
             .with_iter_limit(limits.iter)
-            .with_time_limit(Duration::from_secs(limits.time))
+            .with_time_limit(Duration::from_secs(600))
             .with_egraph(egraph)
     }
 
@@ -223,7 +223,6 @@ impl<L: SynthLanguage> Ruleset<L> {
         let (new_egraph, unions, stop_reason) = lifting_rules.compress_egraph(
             egraph.clone(),
             Limits {
-                time: 1000,
                 iter: usize::MAX,
                 node: usize::MAX,
             },
@@ -421,7 +420,6 @@ impl<L: SynthLanguage> Ruleset<L> {
                     Self::mk_runner(
                         runner.egraph,
                         Limits {
-                            time: 100,
                             iter: usize::MAX,
                             node: usize::MAX,
                         },
@@ -443,7 +441,6 @@ impl<L: SynthLanguage> Ruleset<L> {
                     Self::mk_runner(
                         runner.egraph,
                         Limits {
-                            time: limits.time,
                             iter: 1,
                             node: limits.node,
                         },
@@ -465,7 +462,6 @@ impl<L: SynthLanguage> Ruleset<L> {
                 Self::mk_runner(
                     runner.egraph,
                     Limits {
-                        time: 30,
                         iter: usize::MAX,
                         node: usize::MAX,
                     },

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -148,6 +148,7 @@ impl<L: SynthLanguage> Ruleset<L> {
             .with_scheduler(egg::SimpleScheduler)
             .with_node_limit(limits.node)
             .with_iter_limit(limits.iter)
+            // Egg default time limit is 5 seconds. Bump up to 10 minutes to reduce variance due to timing
             .with_time_limit(Duration::from_secs(600))
             .with_egraph(egraph)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ impl<L: SynthLanguage> egg::CostFunction<L> for ExtractableAstSize {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Limits {
-    pub time: u64,
     pub iter: usize,
     pub node: usize,
 }
@@ -62,7 +61,6 @@ pub struct Limits {
 impl Default for Limits {
     fn default() -> Self {
         Self {
-            time: 30,
             iter: 3,
             node: 300000,
         }

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -217,7 +217,6 @@ mod test {
             iter_bool(3),
             Ruleset::default(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },
@@ -228,7 +227,6 @@ mod test {
             iter_bool(4),
             Ruleset::default(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },
@@ -238,7 +236,6 @@ mod test {
         let (can, cannot) = three.derive(
             four,
             Limits {
-                time: 30,
                 iter: 2,
                 node: 1000000,
             },

--- a/tests/nat.rs
+++ b/tests/nat.rs
@@ -190,7 +190,6 @@ mod test {
             atoms3,
             all_rules.clone(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },
@@ -205,7 +204,6 @@ mod test {
             atoms4,
             all_rules.clone(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },
@@ -220,7 +218,6 @@ mod test {
             atoms5,
             all_rules.clone(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },

--- a/tests/pos.rs
+++ b/tests/pos.rs
@@ -146,7 +146,6 @@ mod tests {
             atoms3,
             all_rules.clone(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },
@@ -161,7 +160,6 @@ mod tests {
             atoms4,
             all_rules.clone(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },
@@ -176,7 +174,6 @@ mod tests {
             atoms5,
             all_rules.clone(),
             Limits {
-                time: 30,
                 iter: 3,
                 node: 1000000,
             },


### PR DESCRIPTION
Time limits are a cause of non-determinism for egg applications. By using a standard 10 minute time limit everywhere, we will reduce the variance caused by timing effects. 