### PR TITLE
Add egraph to workload enum

### DIFF
--- a/src/enumo/enumosym.rs
+++ b/src/enumo/enumosym.rs
@@ -1,0 +1,44 @@
+use crate::*;
+
+// This is an extremely minimal implementation of SynthLanguage
+// It is not intended for any real uses.
+// Workloads of arbitrary s-expressions can use EnumoSym as a
+// default type parameter.
+egg::define_language! {
+  pub enum EnumoSym {
+    Sym(egg::Symbol),
+  }
+}
+
+impl SynthLanguage for EnumoSym {
+    type Constant = usize;
+
+    fn eval<'a, F>(&'a self, _cvec_len: usize, _get_cvec: F) -> CVec<Self>
+    where
+        F: FnMut(&'a Id) -> &'a CVec<Self>,
+    {
+        vec![]
+    }
+
+    fn initialize_vars(_egraph: &mut EGraph<Self, SynthAnalysis>, _vars: &[String]) {}
+
+    fn to_var(&self) -> Option<Symbol> {
+        None
+    }
+
+    fn mk_var(sym: Symbol) -> Self {
+        EnumoSym::Sym(sym)
+    }
+
+    fn is_constant(&self) -> bool {
+        false
+    }
+
+    fn mk_constant(_c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
+        EnumoSym::Sym("".into())
+    }
+
+    fn validate(_lhs: &Pattern<Self>, _rhs: &Pattern<Self>) -> ValidationResult {
+        ValidationResult::Unknown
+    }
+}

--- a/src/enumo/filter.rs
+++ b/src/enumo/filter.rs
@@ -35,7 +35,7 @@ mod test {
 
     #[test]
     fn metric_lt() {
-        let wkld = Workload::from_vec(vec![
+        let wkld: Workload<EnumoSym> = Workload::from_vec(vec![
             "(+ a a)",
             "(+ a b)",
             "(+ a (+ a b))",
@@ -45,13 +45,14 @@ mod test {
             "(~ (+ a b))",
         ]);
         let actual = wkld.filter(Filter::MetricLt(Metric::Atoms, 5)).force();
-        let expected = Workload::from_vec(vec!["(+ a a)", "(+ a b)", "(~ (+ a b))"]).force();
+        let expected =
+            Workload::<EnumoSym>::from_vec(vec!["(+ a a)", "(+ a b)", "(~ (+ a b))"]).force();
         assert_eq!(actual, expected)
     }
 
     #[test]
     fn contains() {
-        let wkld = Workload::from_vec(vec![
+        let wkld: Workload<EnumoSym> = Workload::from_vec(vec![
             "(+ a a)",
             "(+ a b)",
             "(+ a (+ a b))",
@@ -63,13 +64,14 @@ mod test {
             .filter(Filter::Contains("(+ ?x ?x)".parse().unwrap()))
             .force();
         let expected =
-            Workload::from_vec(vec!["(+ a a)", "(+ a (+ b b))", "(+ (+ a b) (+ a b))"]).force();
+            Workload::<EnumoSym>::from_vec(vec!["(+ a a)", "(+ a (+ b b))", "(+ (+ a b) (+ a b))"])
+                .force();
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn and() {
-        let wkld = Workload::from_vec(vec![
+        let wkld: Workload<EnumoSym> = Workload::from_vec(vec![
             "x", "y", "(x y)", "(y x)", "(x x x)", "(y y z)", "(x y z)",
         ]);
         let actual = wkld
@@ -78,7 +80,7 @@ mod test {
                 Box::new(Filter::Contains("y".parse().unwrap())),
             ))
             .force();
-        let expected = Workload::from_vec(vec!["(x y)", "(y x)", "(x y z)"]).force();
+        let expected = Workload::<EnumoSym>::from_vec(vec!["(x y)", "(y x)", "(x y z)"]).force();
         assert_eq!(actual, expected);
     }
 }

--- a/src/enumo/mod.rs
+++ b/src/enumo/mod.rs
@@ -1,5 +1,6 @@
 use crate::HashMap;
 
+pub use enumosym::*;
 pub use filter::*;
 pub use metric::*;
 pub use pattern::*;
@@ -7,6 +8,7 @@ pub use ruleset::*;
 pub use sexp::*;
 pub use workload::*;
 
+mod enumosym;
 mod filter;
 mod metric;
 mod pattern;

--- a/src/enumo/pattern.rs
+++ b/src/enumo/pattern.rs
@@ -98,7 +98,7 @@ impl Pattern {
 
 #[cfg(test)]
 mod test {
-    use crate::enumo::Workload;
+    use crate::enumo::{EnumoSym, Workload};
 
     use super::Pattern;
 
@@ -136,8 +136,14 @@ mod test {
             .map(|x| x.parse::<Pattern>().unwrap())
             .collect();
 
-        let exprs =
-            Workload::from_vec(vec!["a", "x", "(+ x y)", "(+ y y)", "(+ (* a b) (* a b))"]).force();
+        let exprs = Workload::<EnumoSym>::from_vec(vec![
+            "a",
+            "x",
+            "(+ x y)",
+            "(+ y y)",
+            "(+ (* a b) (* a b))",
+        ])
+        .force();
 
         let expected = vec![
             vec![true, true, true, true, true],

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -197,7 +197,7 @@ impl<L: SynthLanguage> Ruleset<L> {
         let mut egraph = workload.to_egraph();
         let (_, unions, _) = self.compress_egraph(egraph.clone(), limits);
         Self::apply_unions(&mut egraph, unions);
-        Workload::EGraph(egraph)
+        Workload::EGraph(Box::new(egraph))
         // extract the smallest term from each eclass and make a workload out of those terms?
     }
 

--- a/src/enumo/sexp.rs
+++ b/src/enumo/sexp.rs
@@ -186,7 +186,7 @@ mod test {
     #[test]
     fn plug() {
         let x = "x".parse::<Sexp>().unwrap();
-        let pegs = Workload::from_vec(vec!["1", "2", "3"]).force();
+        let pegs = Workload::<EnumoSym>::from_vec(vec!["1", "2", "3"]).force();
         let expected = vec![x.clone()];
         let actual = x.plug("a", &pegs);
         assert_eq!(actual, expected);
@@ -199,8 +199,8 @@ mod test {
     #[test]
     fn plug_cross_product() {
         let term = "(x x)";
-        let pegs = Workload::from_vec(vec!["1", "2", "3"]).force();
-        let expected = Workload::from_vec(vec![
+        let pegs = Workload::<EnumoSym>::from_vec(vec!["1", "2", "3"]).force();
+        let expected = Workload::<EnumoSym>::from_vec(vec![
             "(1 1)", "(1 2)", "(1 3)", "(2 1)", "(2 2)", "(2 3)", "(3 1)", "(3 2)", "(3 3)",
         ])
         .force();
@@ -210,11 +210,11 @@ mod test {
 
     #[test]
     fn multi_plug() {
-        let wkld = Workload::from_vec(vec!["(a b)", "(a)", "(b)"]);
+        let wkld: Workload<EnumoSym> = Workload::from_vec(vec!["(a b)", "(a)", "(b)"]);
         let a_s = Workload::from_vec(vec!["1", "2", "3"]);
         let b_s = Workload::from_vec(vec!["x", "y"]);
         let actual = wkld.plug("a", &a_s).plug("b", &b_s).force();
-        let expected = Workload::from_vec(vec![
+        let expected = Workload::<EnumoSym>::from_vec(vec![
             "(1 x)", "(1 y)", "(2 x)", "(2 y)", "(3 x)", "(3 y)", "(1)", "(2)", "(3)", "(x)", "(y)",
         ])
         .force();
@@ -223,7 +223,7 @@ mod test {
 
     #[test]
     fn canon() {
-        let inputs = Workload::from_vec(vec![
+        let inputs = Workload::<EnumoSym>::from_vec(vec![
             "(+ (/ c b) a)",
             "(+ (- c c) (/ a a))",
             "a",
@@ -241,7 +241,7 @@ mod test {
             "(+ a (+ c b))",
         ])
         .force();
-        let expecteds = Workload::from_vec(vec![
+        let expecteds = Workload::<EnumoSym>::from_vec(vec![
             "(+ (/ a b) c)",
             "(+ (- a a) (/ b b))",
             "a",

--- a/src/enumo/workload.rs
+++ b/src/enumo/workload.rs
@@ -10,7 +10,7 @@ pub enum Workload<L: SynthLanguage> {
     Plug(Box<Self>, String, Box<Self>),
     Filter(Filter, Box<Self>),
     Append(Vec<Self>),
-    EGraph(EGraph<L, SynthAnalysis>),
+    EGraph(Box<EGraph<L, SynthAnalysis>>),
 }
 
 impl<L: SynthLanguage> Eq for Workload<L> {}
@@ -37,7 +37,7 @@ impl<L: SynthLanguage> Workload<L> {
 
     pub fn to_egraph(&self) -> EGraph<L, SynthAnalysis> {
         if let Workload::EGraph(e) = self {
-            return e.clone();
+            return *e.clone();
         }
 
         let mut egraph = EGraph::default();

--- a/src/language.rs
+++ b/src/language.rs
@@ -253,14 +253,16 @@ pub trait SynthLanguage: Language + Send + Sync + Display + FromOp + 'static {
     fn validate(lhs: &Pattern<Self>, rhs: &Pattern<Self>) -> ValidationResult;
 
     fn run_workload(
-        workload: Workload,
+        workload: Workload<Self>,
         prior_rules: Ruleset<Self>,
         limits: Limits,
     ) -> Ruleset<Self> {
         let t = Instant::now();
 
+        println!("workload size: {}", workload.force().len());
+
         let mut candidates = if Self::is_rule_lifting() {
-            let mut egraph = workload.to_egraph::<Self>();
+            let mut egraph = workload.to_egraph();
             Ruleset::lift_rules(&mut egraph, prior_rules.clone(), limits)
         } else {
             let egraph = prior_rules.compress_workload(workload, limits);

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -124,7 +124,7 @@ mod test {
 
     use super::*;
 
-    fn iter_bool(n: usize) -> Workload {
+    fn iter_bool(n: usize) -> Workload<Bool> {
         Workload::iter_lang(
             n,
             &["true", "false"],

--- a/tests/nat.rs
+++ b/tests/nat.rs
@@ -176,7 +176,7 @@ mod test {
 
     use super::*;
 
-    fn iter_nat(n: usize) -> Workload {
+    fn iter_nat(n: usize) -> Workload<Nat> {
         Workload::iter_lang(n, &["Z"], &["a", "b", "c"], &["S"], &["+", "*"])
     }
 

--- a/tests/pos.rs
+++ b/tests/pos.rs
@@ -115,7 +115,7 @@ mod tests {
 
     use super::*;
 
-    fn iter_pos(n: usize) -> Workload {
+    fn iter_pos(n: usize) -> Workload<Pos> {
         Workload::iter_lang(n, &["XH"], &["a", "b", "c"], &["XO", "XI"], &["+", "*"])
     }
 


### PR DESCRIPTION
Most of this change is the fallout from adding a type parameter to `Workload` so that `EGraph` can be added as a variant.

2 open questions:
1. How do we compare equality of egraphs? 
2. How do we extract the terms represented by an egraph?

Also mostly a question for @mwillsey - is this an acceptable thing to do in Rust? Is there a better way?