### PR TITLE
Constructor and Iterators for Ruleset

### DIFF
--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -1,5 +1,5 @@
 use egg::{AstSize, EClass, Extractor, StopReason};
-use indexmap::map::{Iter, IterMut, Values, ValuesMut, IntoIter};
+use indexmap::map::{IntoIter, Iter, IterMut, Values, ValuesMut};
 use serde_json::*;
 use std::fs::*;
 use std::{io::Read, io::Write, sync::Arc, time::Duration};
@@ -68,7 +68,10 @@ impl<L: SynthLanguage> Ruleset<L> {
         I::Item: AsRef<str>,
     {
         let mut map = IndexMap::default();
-        let eqs: Vec<Equality<L>> = vals.into_iter().map(|x| x.as_ref().parse().unwrap()).collect();
+        let eqs: Vec<Equality<L>> = vals
+            .into_iter()
+            .map(|x| x.as_ref().parse().unwrap())
+            .collect();
         for eq in eqs {
             map.insert(eq.name.clone(), eq);
         }

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -34,6 +34,15 @@ impl<L: SynthLanguage> Default for Ruleset<L> {
 }
 
 impl<L: SynthLanguage> Ruleset<L> {
+    pub fn new<'a>(vals: impl IntoIterator<Item = &'a str>) -> Self {
+        let mut map = IndexMap::default();
+        let eqs: Vec<Equality<L>> = vals.into_iter().map(|x| x.parse().unwrap()).collect();
+        for eq in eqs {
+            map.insert(eq.name.clone(), eq);
+        }
+        Ruleset(map)
+    }
+
     pub fn from_str_vec(ss: &[&str]) -> Self {
         let mut map = IndexMap::default();
         let eqs: Vec<Equality<L>> = ss.iter().map(|s| s.parse().unwrap()).collect();

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -34,18 +34,13 @@ impl<L: SynthLanguage> Default for Ruleset<L> {
 }
 
 impl<L: SynthLanguage> Ruleset<L> {
-    pub fn new<'a>(vals: impl IntoIterator<Item = &'a str>) -> Self {
+    pub fn new<I>(vals: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
         let mut map = IndexMap::default();
-        let eqs: Vec<Equality<L>> = vals.into_iter().map(|x| x.parse().unwrap()).collect();
-        for eq in eqs {
-            map.insert(eq.name.clone(), eq);
-        }
-        Ruleset(map)
-    }
-
-    pub fn from_str_vec(ss: &[&str]) -> Self {
-        let mut map = IndexMap::default();
-        let eqs: Vec<Equality<L>> = ss.iter().map(|s| s.parse().unwrap()).collect();
+        let eqs: Vec<Equality<L>> = vals.into_iter().map(|x| x.as_ref().parse().unwrap()).collect();
         for eq in eqs {
             map.insert(eq.name.clone(), eq);
         }

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -1,4 +1,5 @@
 use egg::{AstSize, EClass, Extractor, StopReason};
+use indexmap::map::{Iter, IterMut, Values, ValuesMut, IntoIter};
 use serde_json::*;
 use std::fs::*;
 use std::{io::Read, io::Write, sync::Arc, time::Duration};
@@ -33,6 +34,33 @@ impl<L: SynthLanguage> Default for Ruleset<L> {
     }
 }
 
+impl<L: SynthLanguage> IntoIterator for Ruleset<L> {
+    type Item = (Arc<str>, Equality<L>);
+    type IntoIter = IntoIter<Arc<str>, Equality<L>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, L: SynthLanguage> IntoIterator for &'a Ruleset<L> {
+    type Item = (&'a Arc<str>, &'a Equality<L>);
+    type IntoIter = Iter<'a, Arc<str>, Equality<L>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, L: SynthLanguage> IntoIterator for &'a mut Ruleset<L> {
+    type Item = (&'a Arc<str>, &'a mut Equality<L>);
+    type IntoIter = IterMut<'a, Arc<str>, Equality<L>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
 impl<L: SynthLanguage> Ruleset<L> {
     pub fn new<I>(vals: I) -> Self
     where
@@ -45,6 +73,14 @@ impl<L: SynthLanguage> Ruleset<L> {
             map.insert(eq.name.clone(), eq);
         }
         Ruleset(map)
+    }
+
+    pub fn iter(&self) -> Values<'_, Arc<str>, Equality<L>> {
+        self.0.values()
+    }
+
+    pub fn iter_mut(&mut self) -> ValuesMut<'_, Arc<str>, Equality<L>> {
+        self.0.values_mut()
     }
 
     pub fn to_str_vec(&self) -> Vec<String> {

--- a/src/enumo/workload.rs
+++ b/src/enumo/workload.rs
@@ -13,8 +13,12 @@ pub enum Workload {
 }
 
 impl Workload {
-    pub fn new<'a>(vals: impl IntoIterator<Item = &'a str>) -> Self {
-        Self::Set(vals.into_iter().map(|x| x.parse().unwrap()).collect())
+    pub fn new<I>(vals: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        Self::Set(vals.into_iter().map(|x| x.as_ref().parse().unwrap()).collect())
     }
 
     pub fn to_file(&self, filename: &str) {

--- a/src/enumo/workload.rs
+++ b/src/enumo/workload.rs
@@ -18,7 +18,11 @@ impl Workload {
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        Self::Set(vals.into_iter().map(|x| x.as_ref().parse().unwrap()).collect())
+        Self::Set(
+            vals.into_iter()
+                .map(|x| x.as_ref().parse().unwrap())
+                .collect(),
+        )
     }
 
     pub fn to_file(&self, filename: &str) {

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -247,7 +247,7 @@ mod test {
 
     #[test]
     fn round_trip_to_file() {
-        let rules: Ruleset<Bool> = Ruleset::from_str_vec(&[
+        let rules: Ruleset<Bool> = Ruleset::new(&[
             "(^ ?b ?a) ==> (^ ?a ?b)",
             "(& ?b ?a) ==> (& ?a ?b)",
             "(| ?b ?a) ==> (| ?a ?b)",

--- a/tests/bv-bool.rs
+++ b/tests/bv-bool.rs
@@ -40,7 +40,7 @@ impl SynthLanguage for BvBool {
     }
 
     fn get_lifting_rules() -> Ruleset<Self> {
-        let mut rules = Ruleset::from_str_vec(&[
+        let mut rules = Ruleset::new(&[
             "(first (not ?a)) ==> (~ (first ?a))",
             "(second (not ?a)) ==> (~ (second ?a))",
             "(first (and ?a ?b)) ==> (& (first ?a) (first ?b))",

--- a/tests/pos.rs
+++ b/tests/pos.rs
@@ -51,7 +51,7 @@ impl SynthLanguage for Pos {
     }
 
     fn get_lifting_rules() -> Ruleset<Self> {
-        Ruleset::from_str_vec(&[
+        Ruleset::new(&[
             "XH ==> (S Z)",
             "(S Z) ==> XH",
             "(XO ?a) ==> (+ ?a ?a)",
@@ -136,7 +136,7 @@ mod tests {
             "(+ ?a ?a) ==> (* ?a (S (S Z)))",
         ];
 
-        let prior = Ruleset::from_str_vec(&nat_rules);
+        let prior = Ruleset::new(&nat_rules);
 
         let atoms3 = iter_pos(3);
         assert_eq!(atoms3.force().len(), 51);
@@ -186,7 +186,7 @@ mod tests {
         ];
 
         let mut all_rules = Ruleset::default();
-        all_rules.extend(Ruleset::from_str_vec(&nat_rules));
+        all_rules.extend(Ruleset::new(&nat_rules));
 
         let atoms3 = iter_pos(3);
         assert_eq!(atoms3.force().len(), 51);

--- a/tests/trig.rs
+++ b/tests/trig.rs
@@ -150,7 +150,7 @@ impl SynthLanguage for Trig {
     }
 
     fn get_lifting_rules() -> Ruleset<Self> {
-        Ruleset::from_str_vec(&[
+        Ruleset::new(&[
             // definition of sine, cosine, tangent
             "(sin ?a) ==> (/ (- (cis ?a) (cis (~ ?a))) (* 2 I))",
             "(/ (- (cis ?a) (cis (~ ?a))) (* 2 I)) ==> (sin ?a)",


### PR DESCRIPTION
This PR adds `new`, `iter()`, `iter_mut()`, `into_iter()` methods to the Ruleset struct.