### PR TITLE
Fix `run_workload` for exponential domain

### DIFF
--- a/tests/exponential.rs
+++ b/tests/exponential.rs
@@ -116,11 +116,9 @@ impl Exponential {
         let t = Instant::now();
 
         let egraph = workload.to_egraph::<Self>();
-        let compressed = prior.compress(&egraph, limits);
-
-        let mut candidates = Ruleset::cvec_match(&compressed);
-
         let num_prior = prior.len();
+        let mut candidates = Ruleset::allow_forbid_actual(egraph, prior.clone(), limits);
+
         let chosen = candidates.minimize(prior, limits);
         let time = t.elapsed().as_secs_f64();
 


### PR DESCRIPTION
This PR fixes `run_workload` in the exponential domain. It was erroneously trying to cvec match, but this is a lifting domain.