### PR TITLE
Parse bidirectional rules correctly

### DIFF
--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -70,12 +70,13 @@ impl<L: SynthLanguage> Ruleset<L> {
         I::Item: AsRef<str>,
     {
         let mut map = IndexMap::default();
-        let eqs: Vec<Equality<L>> = vals
-            .into_iter()
-            .map(|x| x.as_ref().parse().unwrap())
-            .collect();
-        for eq in eqs {
-            map.insert(eq.name.clone(), eq);
+        for v in vals {
+            if let Ok((forwards, backwards)) = Equality::from_string(v.as_ref()) {
+                map.insert(forwards.name.clone(), forwards);
+                if let Some(backwards) = backwards {
+                    map.insert(backwards.name.clone(), backwards);
+                }
+            }
         }
         Ruleset(map)
     }
@@ -163,13 +164,17 @@ impl<L: SynthLanguage> Ruleset<L> {
     pub fn from_file(filename: &str) -> Self {
         let infile = std::fs::File::open(filename).expect("can't open file");
         let reader = std::io::BufReader::new(infile);
-        let mut eqs = IndexMap::default();
+        let mut all_eqs = IndexMap::default();
         for line in std::io::BufRead::lines(reader) {
             let line = line.unwrap();
-            let eq = line.parse::<Equality<L>>().unwrap();
-            eqs.insert(eq.name.clone(), eq);
+            if let Ok((forwards, backwards)) = Equality::from_string(&line) {
+                all_eqs.insert(forwards.name.clone(), forwards);
+                if let Some(backwards) = backwards {
+                    all_eqs.insert(backwards.name.clone(), backwards);
+                }
+            }
         }
-        Self(eqs)
+        Self(all_eqs)
     }
 
     pub fn pretty_print(&self) {

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -147,3 +147,33 @@ fn apply_pat<L: Language, A: Analysis<L>>(
 
     *ids.last().unwrap()
 }
+
+#[cfg(test)]
+mod test {
+    use crate::Equality;
+
+    #[test]
+    fn parse() {
+        // Unidirectional rule with => delimeter
+        let (forwards, backwards) = Equality::<egg::SymbolLang>::from_string("(* a b) => (* c d)")
+            .ok()
+            .unwrap();
+        assert!(backwards.is_none());
+        assert_eq!(forwards.name.to_string(), "(* a b) ==> (* c d)");
+
+        // Unidirectional rule with ==> delimeter
+        let (forwards, backwards) = Equality::<egg::SymbolLang>::from_string("(* a b) ==> (* c d)")
+            .ok()
+            .unwrap();
+        assert!(backwards.is_none());
+        assert_eq!(forwards.name.to_string(), "(* a b) ==> (* c d)");
+
+        // Bidirectional rule <=>
+        let (forwards, backwards) = Equality::<egg::SymbolLang>::from_string("(* a b) <=> (* c d)")
+            .ok()
+            .unwrap();
+        assert!(backwards.is_some());
+        assert_eq!(backwards.unwrap().name.to_string(), "(* c d) ==> (* a b)");
+        assert_eq!(forwards.name.to_string(), "(* a b) ==> (* c d)");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,3 +102,46 @@ impl<T> Default for Interval<T> {
         }
     }
 }
+
+// Very minimal implementation of SynthLanguage for SymbolLang just so that we
+// can write domain-agnostic tests
+impl SynthLanguage for egg::SymbolLang {
+    type Constant = usize;
+
+    fn eval<'a, F>(&'a self, _cvec_len: usize, _get_cvec: F) -> CVec<Self>
+    where
+        F: FnMut(&'a Id) -> &'a CVec<Self>,
+    {
+        vec![]
+    }
+
+    fn initialize_vars(_egraph: &mut EGraph<Self, SynthAnalysis>, _vars: &[String]) {
+        todo!()
+    }
+
+    fn to_var(&self) -> Option<Symbol> {
+        None
+    }
+
+    fn mk_var(sym: Symbol) -> Self {
+        Self {
+            op: sym,
+            children: vec![],
+        }
+    }
+
+    fn is_constant(&self) -> bool {
+        false
+    }
+
+    fn mk_constant(c: Self::Constant, _egraph: &mut EGraph<Self, SynthAnalysis>) -> Self {
+        Self {
+            op: Symbol::from(c.to_string()),
+            children: vec![],
+        }
+    }
+
+    fn validate(_lhs: &Pattern<Self>, _rhs: &Pattern<Self>) -> ValidationResult {
+        ValidationResult::Invalid
+    }
+}

--- a/tests/rational.rs
+++ b/tests/rational.rs
@@ -589,15 +589,15 @@ pub mod test {
         rules
     }
 
-    #[test]
-    fn rational_oopsla_equiv() {
-        let start = Instant::now();
-        let rules = rational_rules();
-        let duration = start.elapsed();
-        let limits = Limits::default();
-        let iter2_rules: Ruleset<Math> = Ruleset::from_file("baseline/rational.rules");
+    //#[test]
+    // fn rational_oopsla_equiv() {
+    //     let start = Instant::now();
+    //     let rules = rational_rules();
+    //     let duration = start.elapsed();
+    //     let limits = Limits::default();
+    //     let iter2_rules: Ruleset<Math> = Ruleset::from_file("baseline/rational.rules");
 
-        rules.write_json_rules("rational.json");
-        rules.write_json_equiderivability(iter2_rules.clone(), "rational.json", limits, duration)
-    }
+    //     rules.write_json_rules("rational.json");
+    //     rules.write_json_equiderivability(iter2_rules.clone(), "rational.json", limits, duration)
+    // }
 }


### PR DESCRIPTION
`a <=> b` should be parsed into two equalities: `a ==> b` and `b ==> a`