### PR TITLE
Make unit tests less fragile

### DIFF
--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -173,7 +173,6 @@ mod test {
         let egraph = Scheduler::Compress(Limits::default()).run(&atoms3.to_egraph(), &all_rules);
         let mut candidates = Ruleset::cvec_match(&egraph);
         let rules3 = candidates.minimize(all_rules.clone(), Limits::default());
-        assert_eq!(rules3.len(), 23);
         all_rules.extend(rules3);
 
         let atoms4 = iter_bool(4);
@@ -182,7 +181,6 @@ mod test {
         let egraph = Scheduler::Compress(Limits::default()).run(&atoms4.to_egraph(), &all_rules);
         candidates = Ruleset::cvec_match(&egraph);
         let rules4 = candidates.minimize(all_rules.clone(), Limits::default());
-        assert_eq!(rules4.len(), 4);
         all_rules.extend(rules4);
 
         let atoms5 = iter_bool(5);
@@ -191,8 +189,43 @@ mod test {
         let egraph = Scheduler::Compress(Limits::default()).run(&atoms5.to_egraph(), &all_rules);
         candidates = Ruleset::cvec_match(&egraph);
         let rules5 = candidates.minimize(all_rules.clone(), Limits::default());
-        assert_eq!(rules5.len(), 16);
         all_rules.extend(rules5);
+
+        let expected: Ruleset<Bool> = Ruleset::new(&[
+            "(^ ?b ?a) ==> (^ ?a ?b)",
+            "(& ?b ?a) ==> (& ?a ?b)",
+            "(| ?b ?a) ==> (| ?a ?b)",
+            "(& ?a ?a) <=> ?a",
+            "?a <=> (~ (~ ?a))",
+            "?a <=> (| ?a ?a)",
+            "(-> ?a ?a) ==> true",
+            "(^ ?a ?a) ==> false",
+            "(| ?a false) <=> ?a",
+            "?a <=> (-> true ?a)",
+            "?a <=> (& ?a true)",
+            "?a <=> (^ false ?a)",
+            "(~ ?a) <=> (-> ?a false)",
+            "(~ ?a) <=> (^ ?a true)",
+            "(-> ?b (~ ?a)) <=> (~ (& ?b ?a))",
+            "(~ (^ ?b ?a)) ==> (^ ?b (~ ?a))",
+            "(-> (~ ?b) ?a) ==> (| ?a ?b)",
+            "(-> ?b (~ ?a)) ==> (^ ?a (-> ?a ?b))",
+            "(| ?b ?a) ==> (-> (-> ?b ?a) ?a)",
+            "(-> ?b ?a) <=> (-> (| ?a ?b) ?a)",
+            "(| ?b ?a) <=> (| ?a (^ ?b ?a))",
+            "(& ?b ?a) ==> (& ?b (-> ?b ?a))",
+            "(| ?b (& ?b ?a)) ==> ?b",
+            "(& ?a (| ?b ?a)) ==> ?a",
+            "(& ?a (-> ?b ?a)) ==> ?a",
+            "(-> (-> ?a ?b) ?a) ==> ?a",
+            "(-> ?c (-> ?b ?a)) <=> (-> (& ?c ?b) ?a)",
+            "(| ?c (| ?b ?a)) ==> (| ?a (| ?b ?c))",
+            "(-> ?c (-> ?b ?a)) ==> (-> ?b (-> ?c ?a))",
+            "(^ ?c (^ ?b ?a)) ==> (^ ?a (^ ?c ?b))",
+        ]);
+        let (can, cannot) = all_rules.derive(expected.clone(), Limits::default());
+        assert_eq!(can.len(), expected.len());
+        assert_eq!(cannot.len(), 0);
     }
 
     #[test]
@@ -202,22 +235,55 @@ mod test {
         assert_eq!(atoms3.force().len(), 93);
 
         let rules3 = Bool::run_workload(atoms3, all_rules.clone(), Limits::default());
-        assert_eq!(rules3.len(), 23);
         all_rules.extend(rules3);
 
         let atoms4 = iter_bool(4);
         assert_eq!(atoms4.force().len(), 348);
 
         let rules4 = Bool::run_workload(atoms4, all_rules.clone(), Limits::default());
-        assert_eq!(rules4.len(), 4);
         all_rules.extend(rules4);
 
         let atoms5 = iter_bool(5);
         assert_eq!(atoms5.force().len(), 4599);
 
         let rules5 = Bool::run_workload(atoms5, all_rules.clone(), Limits::default());
-        assert_eq!(rules5.len(), 16);
         all_rules.extend(rules5);
+
+        let expected: Ruleset<Bool> = Ruleset::new(&[
+            "(^ ?b ?a) ==> (^ ?a ?b)",
+            "(& ?b ?a) ==> (& ?a ?b)",
+            "(| ?b ?a) ==> (| ?a ?b)",
+            "(& ?a ?a) <=> ?a",
+            "?a <=> (~ (~ ?a))",
+            "?a <=> (| ?a ?a)",
+            "(-> ?a ?a) ==> true",
+            "(^ ?a ?a) ==> false",
+            "(| ?a false) <=> ?a",
+            "?a <=> (-> true ?a)",
+            "?a <=> (& ?a true)",
+            "?a <=> (^ false ?a)",
+            "(~ ?a) <=> (-> ?a false)",
+            "(~ ?a) <=> (^ ?a true)",
+            "(-> ?b (~ ?a)) <=> (~ (& ?b ?a))",
+            "(~ (^ ?b ?a)) ==> (^ ?b (~ ?a))",
+            "(-> (~ ?b) ?a) ==> (| ?a ?b)",
+            "(-> ?b (~ ?a)) ==> (^ ?a (-> ?a ?b))",
+            "(| ?b ?a) ==> (-> (-> ?b ?a) ?a)",
+            "(-> ?b ?a) <=> (-> (| ?a ?b) ?a)",
+            "(| ?b ?a) <=> (| ?a (^ ?b ?a))",
+            "(& ?b ?a) ==> (& ?b (-> ?b ?a))",
+            "(| ?b (& ?b ?a)) ==> ?b",
+            "(& ?a (| ?b ?a)) ==> ?a",
+            "(& ?a (-> ?b ?a)) ==> ?a",
+            "(-> (-> ?a ?b) ?a) ==> ?a",
+            "(-> ?c (-> ?b ?a)) <=> (-> (& ?c ?b) ?a)",
+            "(| ?c (| ?b ?a)) ==> (| ?a (| ?b ?c))",
+            "(-> ?c (-> ?b ?a)) ==> (-> ?b (-> ?c ?a))",
+            "(^ ?c (^ ?b ?a)) ==> (^ ?a (^ ?c ?b))",
+        ]);
+        let (can, cannot) = all_rules.derive(expected.clone(), Limits::default());
+        assert_eq!(can.len(), expected.len());
+        assert_eq!(cannot.len(), 0);
     }
 
     #[test]

--- a/tests/nat.rs
+++ b/tests/nat.rs
@@ -227,7 +227,6 @@ mod test {
                 node: 1000000,
             },
         );
-        assert_eq!(rules3.len(), 5);
         all_rules.extend(rules3);
 
         let atoms4 = iter_nat(4);
@@ -241,7 +240,6 @@ mod test {
                 node: 1000000,
             },
         );
-        assert_eq!(rules4.len(), 4);
         all_rules.extend(rules4);
 
         let atoms5 = iter_nat(5);
@@ -255,7 +253,21 @@ mod test {
                 node: 1000000,
             },
         );
-        assert_eq!(rules5.len(), 3);
         all_rules.extend(rules5);
+
+        let expected: Ruleset<Nat> = Ruleset::new(&[
+            "(+ ?b ?a) ==> (+ ?a ?b)",
+            "(* ?b ?a) ==> (* ?a ?b)",
+            "(+ Z ?a) <=> ?a",
+            "(* Z ?a) ==> Z",
+            "?a <=> (* ?a (S Z))",
+            "(+ ?b (S ?a)) <=> (S (+ ?b ?a))",
+            "(+ ?b (* ?b ?a)) ==> (* ?b (S ?a))",
+            "(* ?c (* ?b ?a)) ==> (* ?a (* ?b ?c))",
+            "(+ ?c (+ ?b ?a)) ==> (+ ?a (+ ?b ?c))",
+        ]);
+        let (can, cannot) = all_rules.derive(expected.clone(), Limits::default());
+        assert_eq!(can.len(), expected.len());
+        assert_eq!(cannot.len(), 0);
     }
 }

--- a/tests/pos.rs
+++ b/tests/pos.rs
@@ -229,7 +229,6 @@ mod tests {
                 node: 1000000,
             },
         );
-        assert_eq!(rules3.len(), 6);
         all_rules.extend(rules3);
 
         let atoms4 = iter_pos(4);
@@ -243,7 +242,6 @@ mod tests {
                 node: 1000000,
             },
         );
-        assert_eq!(rules4.len(), 2);
         all_rules.extend(rules4);
 
         let atoms5 = iter_pos(5);
@@ -257,6 +255,28 @@ mod tests {
                 node: 1000000,
             },
         );
-        assert_eq!(rules4.len(), 1);
+        all_rules.extend(rules4);
+
+        let expected: Ruleset<Pos> = Ruleset::new(&[
+            "(+ ?b ?a) ==> (+ ?a ?b)",
+            "(* ?b ?a) ==> (* ?a ?b)",
+            "(+ Z ?a) ==> ?a",
+            "(* ?a Z) ==> Z",
+            "(S (+ ?b ?a)) ==> (+ ?b (S ?a))",
+            "(* ?a (S Z)) ==> ?a",
+            "(+ ?a (S Z)) ==> (S ?a)",
+            "(+ ?c (+ ?b ?a)) ==> (+ ?a (+ ?b ?c))",
+            "(* (* ?c ?b) ?a) ==> (* ?b (* ?c ?a))",
+            "(+ ?b (* ?b ?a)) ==> (* ?b (S ?a))",
+            "(* (+ ?b ?b) ?a) ==> (* ?b (+ ?a ?a))",
+            "(+ ?a ?a) ==> (* ?a (S (S Z)))",
+            "(XI ?a) <=> (+ (XO ?a) XH)",
+            "?a <=> (* ?a XH)",
+            "(XO ?a) <=> (+ ?a ?a)",
+            "(+ ?a (XO ?a)) <=> (* ?a (XI XH))",
+        ]);
+        let (can, cannot) = all_rules.derive(expected.clone(), Limits::default());
+        assert_eq!(can.len(), expected.len());
+        assert_eq!(cannot.len(), 0);
     }
 }

--- a/tests/trig.rs
+++ b/tests/trig.rs
@@ -413,14 +413,12 @@ mod test {
         let rules1 = Trig::run_workload(wkld1.clone(), all.clone(), limits);
         all.extend(rules1.clone());
         new.extend(rules1.clone());
-        assert_eq!(rules1.len(), 22);
 
         let wkld2 = Workload::Append(vec![wkld1, simple_terms, neg_terms]);
         println!("Starting 2");
         let rules2 = Trig::run_workload(wkld2.clone(), all.clone(), limits);
         all.extend(rules2.clone());
         new.extend(rules2.clone());
-        assert_eq!(rules2.len(), 12);
 
         let trimmed_wkld2 = wkld2.clone().filter(no_trig_2x);
         let wkld3 = Workload::Append(vec![trimmed_wkld2.clone(), sum_of_squares.clone()]);
@@ -428,7 +426,32 @@ mod test {
         let rules3 = Trig::run_workload(wkld3, all.clone(), limits);
         all.extend(rules3.clone());
         new.extend(rules3.clone());
-        assert_eq!(rules3.len(), 3);
+
+        let expected: Ruleset<Trig> = Ruleset::new(&[
+            "(sin (/ PI 4)) <=> (cos (/ PI 4))",
+            "(tan (/ PI 4)) <=> (cos 0)",
+            "(sin (/ PI 2)) <=> (cos 0)",
+            "(cos 0) <=> (cos (* PI 2))",
+            "0 <=> (cos (/ PI 2))",
+            "(tan (* PI 2)) <=> 0",
+            "0 <=> (sin (* PI 2))",
+            "(sin 0) <=> 0",
+            "0 <=> (tan 0)",
+            "0 <=> (sin PI)",
+            "(sin PI) <=> (tan PI)",
+            "(~ (cos ?a)) <=> (cos (- PI ?a))",
+            "(sin (- PI ?a)) <=> (sin ?a)",
+            "(tan ?a) <=> (tan (+ PI ?a))",
+            "(~ (sin ?a)) <=> (sin (~ ?a))",
+            "(tan (~ ?a)) <=> (~ (tan ?a))",
+            "(cos (~ ?a)) <=> (cos ?a)",
+            "(+ (* (sin ?a) (sin ?a)) (* (cos ?a) (cos ?a))) ==> (cos 0)",
+            "(- (* (cos ?b) (cos ?b)) (* (cos ?a) (cos ?a))) ==> (- (* (sin ?a) (sin ?a)) (* (sin ?b) (sin ?b)))",
+            "(- (* (sin ?b) (sin ?b)) (* (cos ?a) (cos ?a))) ==> (- (* (sin ?a) (sin ?a)) (* (cos ?b) (cos ?b)))",
+        ]);
+        let (can, cannot) = all.derive(expected.clone(), Limits::default());
+        assert_eq!(can.len(), expected.len());
+        assert_eq!(cannot.len(), 0);
 
         new
     }
@@ -600,6 +623,11 @@ mod test {
         all.extend(prior_rules());
 
         let rules = Trig::run_workload(terms, all, limits);
-        assert_eq!(rules.len(), 6);
+
+        let expected: Ruleset<Trig> =
+            Ruleset::new(&["(sin (* PI 2)) <=> 0", "0 <=> (sin 0)", "0 <=> (sin PI)"]);
+        let (can, cannot) = rules.derive(expected.clone(), Limits::default());
+        assert_eq!(can.len(), expected.len());
+        assert_eq!(cannot.len(), 0);
     }
 }


### PR DESCRIPTION
Pretty much every time these tests have broken it's been because of minor differences in ruleset length that don't actually matter
We really just want to know if the proving power goes way down or something like that