### PR TITLE
Fix filter

### DIFF
--- a/src/enumo/filter.rs
+++ b/src/enumo/filter.rs
@@ -31,6 +31,13 @@ impl Filter {
     pub(crate) fn is_monotonic(&self) -> bool {
         matches!(self, Filter::MetricLt(_, _))
     }
+
+    pub(crate) fn reduce_monotonic(&self) -> Self {
+        match self {
+            Filter::MetricLt(m, n) => Filter::MetricLt(*m, n - 1),
+            _ => self.clone(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/enumo/filter.rs
+++ b/src/enumo/filter.rs
@@ -31,13 +31,6 @@ impl Filter {
     pub(crate) fn is_monotonic(&self) -> bool {
         matches!(self, Filter::MetricLt(_, _))
     }
-
-    pub(crate) fn reduce_monotonic(&self) -> Self {
-        match self {
-            Filter::MetricLt(m, n) => Filter::MetricLt(*m, n - 1),
-            _ => self.clone(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/enumo/workload.rs
+++ b/src/enumo/workload.rs
@@ -274,6 +274,16 @@ mod test {
     }
 
     #[test]
+    fn filter_optimization() {
+        let wkld = Workload::new(["x"]);
+        let pegs = Workload::new(["a", "b", "c"]);
+        let plugged = wkld
+            .plug("x", &pegs)
+            .filter(Filter::MetricLt(Metric::Atoms, 2));
+        assert_eq!(plugged.force().len(), 2);
+    }
+
+    #[test]
     fn contains() {
         let lang = Workload::new(["cnst", "var", "(uop expr)", "(bop expr expr)"]);
 


### PR DESCRIPTION
I was hitting a bottleneck trying to iterate `[var, const, (uop expr), (bop expr expr), (top expr expr expr)]` up to size 6.
I think this optimization on filters is important: you can actually modify the filter that you push down into the plug. So we used to say something like
`wkld.plug("name", pegs).filter(MetricLt(Atoms, n))`
is the same as
`wkld.plug("name", pegs.filter(MetricLt(Atoms, n)).filter(MetricLt(Atoms, n))`
but you can actually make the filter on the pegs stronger-- in the case of `MetricLt`, it's `n-1` not `n` on the peg

This speeds things up quite a bit.

(It's a little late, so i'm not sure how coherent that explanation is, please lmk if there are questions!)