### PR TITLE
Add div to recipe

### DIFF
--- a/src/enumo/filter.rs
+++ b/src/enumo/filter.rs
@@ -3,6 +3,7 @@ use super::*;
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Filter {
     MetricLt(Metric, usize),
+    MetricEq(Metric, usize),
     Contains(Pattern),
     Canon(Vec<String>),
     And(Vec<Self>),
@@ -14,6 +15,7 @@ impl Filter {
     pub(crate) fn test(&self, sexp: &Sexp) -> bool {
         match self {
             Filter::MetricLt(metric, n) => sexp.measure(*metric) < *n,
+            Filter::MetricEq(metric, n) => sexp.measure(*metric) == *n,
             Filter::Contains(pat) => {
                 pat.matches(sexp)
                     || match sexp {

--- a/tests/halide.rs
+++ b/tests/halide.rs
@@ -111,9 +111,13 @@ impl SynthLanguage for Pred {
 
     fn initialize_vars(egraph: &mut EGraph<Self, SynthAnalysis>, vars: &[String]) {
         let consts = vec![
+            Some((-10).to_bigint().unwrap()),
             Some((-1).to_bigint().unwrap()),
             Some(0.to_bigint().unwrap()),
             Some(1.to_bigint().unwrap()),
+            Some(2.to_bigint().unwrap()),
+            Some(5.to_bigint().unwrap()),
+            Some(100.to_bigint().unwrap()),
         ];
         let cvecs = self_product(&consts, vars.len());
 

--- a/tests/recipes/halide.rs
+++ b/tests/recipes/halide.rs
@@ -67,7 +67,7 @@ pub fn halide_rules() -> Ruleset<Pred> {
         &Workload::new(&["-1", "0", "1"]),
         &Workload::new(&["a", "b", "c"]),
         &Workload::new(&["-"]),
-        &Workload::new(&["+", "-", "*", "min", "max"]), // No div for now
+        &Workload::new(&["+", "-", "*", "/", "min", "max"]),
         &Workload::Set(vec![]),
         all_rules.clone(),
     );
@@ -94,7 +94,7 @@ pub fn halide_rules() -> Ruleset<Pred> {
         &Workload::new(&["a", "b", "c"]),
         &Workload::new(&["-", "!"]),
         &Workload::new(&[
-            "&&", "||", "^", "+", "-", "*", "min", "max", "<", "<=", "==", "!=",
+            "&&", "||", "^", "+", "-", "*", "/", "min", "max", "<", "<=", "==", "!=",
         ]),
         &Workload::new(&["select"]),
         all_rules.clone(),


### PR DESCRIPTION
Adding more stuff to the cvec seems to solve the cvec crashes we were seeing earlier.
my guess is that since `0` and `1` are also used as booleans in this domain, we need to have more variety in the cvec to prevent merging constants