### PR TITLE
re-add short circuiting

### DIFF
--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -447,7 +447,7 @@ impl<L: SynthLanguage> Ruleset<L> {
             }
         }
 
-        let out_egraph = scheduler.run(&egraph, self);
+        let out_egraph = scheduler.run_derive(&egraph, self, rule);
 
         let l_id = out_egraph
             .lookup_expr(lexpr)

--- a/src/enumo/scheduler.rs
+++ b/src/enumo/scheduler.rs
@@ -26,15 +26,39 @@ impl Scheduler {
             .with_egraph(egraph)
     }
 
-    pub fn run<L: SynthLanguage>(
+    pub fn run_internal<L: SynthLanguage>(
         &self,
         egraph: &EGraph<L, SynthAnalysis>,
         ruleset: &Ruleset<L>,
+        rule: Option<&Rule<L>>,
     ) -> EGraph<L, SynthAnalysis> {
+        let get_runner = |egraph: EGraph<L, SynthAnalysis>, limits: Limits| {
+            if let Some(rule) = rule {
+                let lexpr = L::instantiate(&rule.lhs);
+                let rexpr = L::instantiate(&rule.rhs);
+
+                Self::mk_runner(egraph, &limits).with_hook(move |r| {
+                    let lhs = r.egraph.lookup_expr(&lexpr);
+                    let rhs = r.egraph.lookup_expr(&rexpr);
+                    match (lhs, rhs) {
+                        (Some(l), Some(r)) => {
+                            if l == r {
+                                Err("Done".to_owned())
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        _ => Ok(()),
+                    }
+                })
+            } else {
+                Self::mk_runner(egraph, &limits)
+            }
+        };
         match self {
             Scheduler::Simple(limits) => {
                 let rewrites = ruleset.0.values().map(|rule| &rule.rewrite);
-                let mut runner = Self::mk_runner(egraph.clone(), limits)
+                let mut runner = get_runner(egraph.clone(), *limits)
                     .with_iter_limit(limits.iter)
                     .with_node_limit(limits.node)
                     .with_scheduler(egg::SimpleScheduler)
@@ -53,23 +77,23 @@ impl Scheduler {
                         .collect()),
                 );
 
-                let mut runner = Self::mk_runner(egraph.clone(), limits);
+                let mut runner = get_runner(egraph.clone(), *limits);
 
                 for _ in 0..limits.iter {
                     // Sat
-                    runner = Self::mk_runner(runner.egraph, &Limits::max()).run(&sat);
+                    runner = get_runner(runner.egraph, Limits::max()).run(&sat);
 
                     // Other
-                    runner = Self::mk_runner(
+                    runner = get_runner(
                         runner.egraph,
-                        &Limits {
+                        Limits {
                             iter: 1,
                             node: limits.node,
                         },
                     )
                     .run(&other);
                 }
-                let mut runner = Self::mk_runner(runner.egraph, &Limits::max()).run(&sat);
+                let mut runner = get_runner(runner.egraph, Limits::max()).run(&sat);
                 runner.egraph.rebuild();
                 runner.egraph
             }
@@ -98,5 +122,22 @@ impl Scheduler {
                 clone
             }
         }
+    }
+
+    pub fn run<L: SynthLanguage>(
+        &self,
+        egraph: &EGraph<L, SynthAnalysis>,
+        ruleset: &Ruleset<L>,
+    ) -> EGraph<L, SynthAnalysis> {
+        self.run_internal(egraph, ruleset, None)
+    }
+
+    pub fn run_derive<L: SynthLanguage>(
+        &self,
+        egraph: &EGraph<L, SynthAnalysis>,
+        ruleset: &Ruleset<L>,
+        rule: &Rule<L>,
+    ) -> EGraph<L, SynthAnalysis> {
+        self.run_internal(egraph, ruleset, Some(rule))
     }
 }


### PR DESCRIPTION
We should short-circuit running eqsat when we're checking derivability- as soon as the lhs and rhs merge, we're done.
We had this previously, it was removed in https://github.com/uwplse/ruler/pull/107, but we should re-add it. I think it will make a big difference in derivability performance