### PR TITLE
Small tweaks to Nightlies UI

### DIFF
--- a/infra/nightly-resources/generate.js
+++ b/infra/nightly-resources/generate.js
@@ -3,8 +3,8 @@ function getBaseline(data, baseline) {
     baseline_name: "Baseline",
     enumo_spec_name: "Enumo Spec",
     loc: "Enumo Spec LOC",
-    num_rules: "\\# Enumo",
-    num_baseline: "\\# Baseline",
+    num_rules: "# Enumo",
+    num_baseline: "# Baseline",
     time: "Time (s)",
     enumo_to_baseline_lhs_num: "E derives B (LHS)",
     enumo_to_baseline_lhsrhs_num: "E derives B (LHSRHS)",
@@ -70,21 +70,53 @@ function load() {
   document.getElementById("halide_table").innerHTML = ConvertJsonToTable(
     getBaseline(data, "halide")
   );
+
+  document.getElementById("detail").innerHTML = populateDomainDetail();
 }
 
-function loadDeriveDetail() {
+function populateDomainDetail() {
+  let domains = data.map((x) => x.enumo_spec_name);
+  let str = "";
+  domains.forEach((domain) => {
+    str += "<p>";
+    str += `${domain}: `;
+    str += `<a href="rules.html?domain=${domain}">All Rules</a> `;
+    str += `<a href="derive_detail.html?domain=${domain}">Derivability</a>`;
+    str += "</p>";
+  });
+  return str;
+}
+
+function getDomainData() {
   let params = new URLSearchParams(window.location.search);
   let domain = Object.fromEntries(params).domain;
 
   if (!domain) {
     return;
   }
-  document.getElementById("domain_name").innerHTML = domain;
 
   let domainData = data.find((x) => x.enumo_spec_name == domain);
   if (!domainData) {
     return;
   }
+  return domainData;
+}
+
+function loadRules() {
+  let domainData = getDomainData();
+  document.getElementById("domain_name").innerHTML = domainData.enumo_spec_name;
+  let rules = domainData.rules.rules;
+  let str = "";
+  rules.forEach((rule) => {
+    str += `${rule} <br />`;
+  });
+  document.getElementById("all_rules").innerHTML = str;
+}
+
+function loadDeriveDetail() {
+  let domainData = getDomainData();
+  document.getElementById("domain_name").innerHTML = domainData.enumo_spec_name;
+
   let deriveTypes = ["lhs", "lhs_rhs", "all"];
   deriveTypes.forEach((deriveType) => {
     document.getElementById(`${deriveType}_etob_can`).innerHTML =
@@ -128,6 +160,8 @@ function tryRound(v) {
 }
 
 function generateLatex(baseline) {
+  let escape = (s) => s.replaceAll("#", "\\#");
+
   let baselineData = getBaseline(data, baseline);
 
   let columnNames = Object.keys(baselineData[0]);
@@ -138,7 +172,9 @@ function generateLatex(baseline) {
     String.raw`\begin{tabular}{` + "l".repeat(columnNames.length) + "}",
   ];
 
-  lines.push(columnNames.join(" & ") + String.raw`\\ \cline{1-${columnNames.length}}`);
+  lines.push(
+    columnNames.join(" & ") + String.raw`\\ \cline{1-${columnNames.length}}`
+  );
 
   baselineData.forEach((row) => {
     lines.push(Object.values(row).join(" & ") + " \\\\");
@@ -149,7 +185,7 @@ function generateLatex(baseline) {
   lines.push(String.raw`\label{table:${baseline}}`);
   lines.push(String.raw`\end{table}`);
 
-  let s = lines.join("\n");
+  let s = lines.map((l) => escape(l)).join("\n");
   let elem = document.getElementById("latex");
   elem.innerHTML = s;
   elem.style.height = "200px";

--- a/infra/nightly-resources/index.html
+++ b/infra/nightly-resources/index.html
@@ -29,24 +29,8 @@
   <div><textarea id="latex"></textarea></div>
 
   <h2>Domain-specific Results</h2>
-  <p>
-    <a href="derive_detail.html?domain=bool">Bool</a>
-  </p>
-  <p>
-    <a href="derive_detail.html?domain=bv4">BV4</a>
-  </p>
-  <p>
-    <a href="derive_detail.html?domain=bv32">BV32</a>
-  </p>
-  <p>
-    <a href="derive_detail.html?domain=halide">Halide</a>
-  </p>
-  <p>
-    <a href="derive_detail.html?domain=rational_replicate">Rational (replicate)</a>
-  </p>
-  <p>
-    <a href="derive_detail.html?domain=rational_best">Rational (best)</a>
-  </p>
+  <div id="detail"></div>
+
   <h2>Raw</h2>
   <p>
     <a href="data/output.js">Data</a>

--- a/infra/nightly-resources/rules.html
+++ b/infra/nightly-resources/rules.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="stylesheet.css" type="text/css" charset="utf-8" />
+<html>
+
+<head>
+  <script src="table.js"></script>
+  <script src="data/output.js"></script>
+  <script src="generate.js"></script>
+</head>
+
+<title>Rules</title>
+
+<body onload="loadRules()">
+  <h2 id="domain_name">Bool</h2>
+  <div id="all_rules"></div>
+  
+</body>


### PR DESCRIPTION
- Escape `#` for latex in latex-generating code so that it still appears as expected in the HTML table
- Make a link to click through and see all rules for each domain (requested by @chandrakananandi )
- Make the domain-specific links auto-generate from the data so that we show all the domains by default and don't have to manually edit the html (for example, trig and exponential were not previously being shown here)