### PR TITLE
Trig recipe cleanup

### DIFF
--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -60,7 +60,7 @@ pub fn run_workload<L: SynthLanguage>(
 }
 
 pub fn run_rule_lifting<L: SynthLanguage>(
-    workload: Workload,
+    workload: &Workload,
     prior: Ruleset<L>,
     limits: Limits,
 ) -> Ruleset<L> {
@@ -72,6 +72,10 @@ pub fn run_rule_lifting<L: SynthLanguage>(
 
     let chosen = candidates.minimize(prior, Scheduler::Compress(limits)).0;
     let time = t.elapsed().as_secs_f64();
+
+    if chosen.is_empty() {
+        panic!("Didn't learn any rules!");
+    }
 
     println!(
         "Learned {} bidirectional rewrites ({} total rewrites) in {} using {} prior rewrites",

--- a/tests/maxmin.rs
+++ b/tests/maxmin.rs
@@ -514,7 +514,7 @@ mod tests {
         // assert_eq!(atoms3.force().len(), 51);
 
         let rules3 = run_rule_lifting(
-            atoms3,
+            &atoms3,
             all_rules.clone(),
             Limits {
                 iter: 3,
@@ -529,7 +529,7 @@ mod tests {
         // assert_eq!(atoms4.force().len(), 255);
 
         let rules4 = run_rule_lifting(
-            atoms4,
+            &atoms4,
             all_rules.clone(),
             Limits {
                 iter: 3,
@@ -544,7 +544,7 @@ mod tests {
         // assert_eq!(atoms5.force().len(), 1527);
 
         let rules4 = run_rule_lifting(
-            atoms5,
+            &atoms5,
             all_rules.clone(),
             Limits {
                 iter: 3,

--- a/tests/pos.rs
+++ b/tests/pos.rs
@@ -201,7 +201,7 @@ mod tests {
         assert_eq!(atoms3.force().len(), 51);
 
         let rules3 = run_rule_lifting(
-            atoms3,
+            &atoms3,
             all_rules.clone(),
             Limits {
                 iter: 3,
@@ -215,7 +215,7 @@ mod tests {
         assert_eq!(atoms4.force().len(), 255);
 
         let rules4 = run_rule_lifting(
-            atoms4,
+            &atoms4,
             all_rules.clone(),
             Limits {
                 iter: 3,
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!(atoms5.force().len(), 1527);
 
         let rules4 = run_rule_lifting(
-            atoms5,
+            &atoms5,
             all_rules.clone(),
             Limits {
                 iter: 3,

--- a/tests/recipes/exponential.rs
+++ b/tests/recipes/exponential.rs
@@ -29,7 +29,7 @@ fn constant_rules(prev_rules: &Ruleset) -> Ruleset {
         "(pow 1 a)",
     ]);
 
-    run_rule_lifting(terms, prev_rules.clone(), limits())
+    run_rule_lifting(&terms, prev_rules.clone(), limits())
 }
 
 fn exp_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -49,7 +49,7 @@ fn exp_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits())
+    run_rule_lifting(&upper_layer, prev_rules.clone(), limits())
 }
 
 fn log_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -69,7 +69,7 @@ fn log_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits())
+    run_rule_lifting(&upper_layer, prev_rules.clone(), limits())
 }
 
 fn no_pow_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -95,7 +95,7 @@ fn no_pow_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits())
+    run_rule_lifting(&upper_layer, prev_rules.clone(), limits())
 }
 
 fn simple_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -121,7 +121,7 @@ fn simple_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits())
+    run_rule_lifting(&upper_layer, prev_rules.clone(), limits())
 }
 
 fn div_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -142,7 +142,7 @@ fn div_rules(prev_rules: &Ruleset) -> Ruleset {
         .plug("bop", &bops)
         .filter(Filter::Canon(str_vec!["a", "b"]));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits())
+    run_rule_lifting(&upper_layer, prev_rules.clone(), limits())
 }
 
 pub fn make_rules() -> Ruleset {

--- a/tests/recipes/trig.rs
+++ b/tests/recipes/trig.rs
@@ -147,10 +147,5 @@ pub fn trig_rules() -> Ruleset<Trig> {
     all.extend(rules.clone());
     new.extend(rules.clone());
 
-    let orig = Ruleset::<Trig>::from_file("trig.rules");
-    let (can, cannot) = all.derive(DeriveType::LhsAndRhs, &orig, limits);
-    println!("{} {}", can.len(), cannot.len());
-    cannot.pretty_print();
-
     new
 }

--- a/tests/trig.rs
+++ b/tests/trig.rs
@@ -350,11 +350,6 @@ mod test {
     }
 
     #[test]
-    fn rules() {
-        trig_rules();
-    }
-
-    #[test]
     fn run() {
         // Skip this test in github actions
         if std::env::var("CI").is_ok() && std::env::var("SKIP_RECIPES").is_ok() {

--- a/tests/trig.rs
+++ b/tests/trig.rs
@@ -350,6 +350,11 @@ mod test {
     }
 
     #[test]
+    fn rules() {
+        trig_rules();
+    }
+
+    #[test]
     fn run() {
         // Skip this test in github actions
         if std::env::var("CI").is_ok() && std::env::var("SKIP_RECIPES").is_ok() {
@@ -390,7 +395,7 @@ mod test {
         let mut all = complex;
         all.extend(prior_rules());
 
-        let rules = run_rule_lifting(terms, all, limits);
+        let rules = run_rule_lifting(&terms, all, limits);
 
         let expected: Ruleset<Trig> =
             Ruleset::new(&["(sin (* PI 2)) <=> 0", "0 <=> (sin 0)", "0 <=> (sin PI)"]);


### PR DESCRIPTION
1. Add `panic!` if `run_rule_lifting` doesn't find rules
2. Restructure the trig recipe so that each phase is self-contained. I think it's easier to tell what's in each workload if there's fewer layers of plugs, and everything is local in the file. Lmk what you think!

The workloads + rules are very similar, but not identical. The new rules can derive 100% of the old rules, though, so hopefully it should be okay.