### PR TITLE
Rename everything to fast-forwarding

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -218,7 +218,7 @@ pub trait SynthLanguage: Language + Send + Sync + Display + FromOp + 'static {
     /// finding candidates.
     /// If fast-forwarding is enabled, L::get_lifting_rewrites() and L::is_allowed_op()
     /// must be implemented
-    fn is_rule_lifting() -> bool {
+    fn is_fast_forwarding() -> bool {
         false
     }
 
@@ -226,7 +226,7 @@ pub trait SynthLanguage: Language + Send + Sync + Display + FromOp + 'static {
     ///
     /// These are the exploratory rules that run in the second phase of the
     /// fast-forwarding algorithm
-    fn get_lifting_rules() -> Ruleset<Self> {
+    fn get_exploratory_rules() -> Ruleset<Self> {
         panic!("No lifting rules")
     }
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -216,7 +216,7 @@ pub trait SynthLanguage: Language + Send + Sync + Display + FromOp + 'static {
 
     /// Configures whether to run fast-forwarding or cvec algorithm for
     /// finding candidates.
-    /// If fast-forwarding is enabled, L::get_lifting_rewrites() and L::is_allowed_op()
+    /// If fast-forwarding is enabled, L::get_exploratory_rules() and L::is_allowed_op()
     /// must be implemented
     fn is_fast_forwarding() -> bool {
         false
@@ -227,7 +227,7 @@ pub trait SynthLanguage: Language + Send + Sync + Display + FromOp + 'static {
     /// These are the exploratory rules that run in the second phase of the
     /// fast-forwarding algorithm
     fn get_exploratory_rules() -> Ruleset<Self> {
-        panic!("No lifting rules")
+        panic!("No exploratory rules")
     }
 
     /// Required for fast-forwarding

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -165,7 +165,7 @@ pub fn write_bv_derivability<L: SynthLanguage>(
  * time: time in seconds
  * rules: array of rules
  */
-pub fn write_lifting_phase<L: SynthLanguage>(
+pub fn write_ff_phase<L: SynthLanguage>(
     phase1: Phase<L>,
     phase2: Phase<L>,
     phase3: Phase<L>,

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -113,13 +113,13 @@ pub fn run_fast_forwarding<L: SynthLanguage>(
     let eg_allowed = Scheduler::Compress(prior_limits).run(&eg_init, &allowed);
 
     // Translation rules: grow egraph, extract candidates, assert!(saturated)
-    let lifting_rules = L::get_exploratory_rules();
-    let eg_denote = Scheduler::Simple(prior_limits).run(&eg_allowed, &lifting_rules);
+    let exploratory = L::get_exploratory_rules();
+    let eg_denote = Scheduler::Simple(prior_limits).run(&eg_allowed, &exploratory);
     let mut candidates = Ruleset::extract_candidates(&eg_allowed, &eg_denote);
 
     // All rules: compress e-graph, extract candidates
     let mut all_rules = prior.clone();
-    all_rules.extend(lifting_rules);
+    all_rules.extend(exploratory);
     let eg_final = Scheduler::Compress(prior_limits).run(&eg_denote, &all_rules);
     candidates.extend(Ruleset::extract_candidates(&eg_denote, &eg_final));
 

--- a/src/recipe_utils.rs
+++ b/src/recipe_utils.rs
@@ -109,9 +109,7 @@ pub fn run_fast_forwarding<L: SynthLanguage>(
     let num_prior = prior.len();
 
     // Allowed rules: compress e-graph, no candidates
-    let (allowed, _) = prior
-        .clone()
-        .partition(|rule| L::is_allowed_rewrite(&rule.lhs, &rule.rhs));
+    let (allowed, _) = prior.partition(|rule| L::is_allowed_rewrite(&rule.lhs, &rule.rhs));
     let eg_allowed = Scheduler::Compress(prior_limits).run(&eg_init, &allowed);
 
     // Translation rules: grow egraph, extract candidates, assert!(saturated)

--- a/tests/bv-bool.rs
+++ b/tests/bv-bool.rs
@@ -38,11 +38,11 @@ fn is_bv_str(s: &'static str) -> impl Fn(&mut EGraph<BvBool, SynthAnalysis>, Id,
 impl SynthLanguage for BvBool {
     type Constant = BV<2>;
 
-    fn is_rule_lifting() -> bool {
+    fn is_fast_forwarding() -> bool {
         true
     }
 
-    fn get_lifting_rules() -> Ruleset<Self> {
+    fn get_exploratory_rules() -> Ruleset<Self> {
         let mut rules = Ruleset::new(&[
             "(first (not ?a)) ==> (~ (first ?a))",
             "(second (not ?a)) ==> (~ (second ?a))",

--- a/tests/exponential.rs
+++ b/tests/exponential.rs
@@ -90,11 +90,11 @@ impl SynthLanguage for Exponential {
         ValidationResult::Valid
     }
 
-    fn is_rule_lifting() -> bool {
+    fn is_fast_forwarding() -> bool {
         true
     }
 
-    fn get_lifting_rules() -> enumo::Ruleset<Self> {
+    fn get_exploratory_rules() -> enumo::Ruleset<Self> {
         enumo::Ruleset::new(&[
             // definitions (denote)
             "(pow ?a ?b) ==> (exp (* ?b (log ?a)))",

--- a/tests/maxmin.rs
+++ b/tests/maxmin.rs
@@ -164,7 +164,7 @@ egg::define_language! {
 impl SynthLanguage for CaddyAndFRep {
     type Constant = Constant;
 
-    fn is_rule_lifting() -> bool {
+    fn is_fast_forwarding() -> bool {
         true
     }
 
@@ -393,7 +393,7 @@ impl SynthLanguage for CaddyAndFRep {
     endcase))
      */
 
-    fn get_lifting_rules() -> Ruleset<Self> {
+    fn get_exploratory_rules() -> Ruleset<Self> {
         Ruleset::new(&[
             "(ite ?c ?t ?e) ==> (case ?c ?t (case (! ?c) ?e endcase))",
             "(max ?a ?b) ==> (ite (< ?a ?b) ?b ?a)",
@@ -452,7 +452,7 @@ impl SynthLanguage for CaddyAndFRep {
 mod tests {
     use ruler::{
         enumo::{Filter, Metric, Ruleset, Scheduler, Workload},
-        recipe_utils::{base_lang, iter_metric, run_rule_lifting},
+        recipe_utils::{base_lang, iter_metric, run_fast_forwarding},
     };
 
     use super::*;
@@ -487,7 +487,7 @@ mod tests {
         let eg_allowed = Scheduler::Compress(limits).run(&eg_init, &allowed);
 
         // Translation rules: grow egraph, extract candidates, assert!(saturated)
-        let lifting_rules = CaddyAndFRep::get_lifting_rules();
+        let lifting_rules = CaddyAndFRep::get_exploratory_rules();
         let eg_denote = Scheduler::Simple(limits).run(&eg_allowed, &lifting_rules);
         let mut candidates = Ruleset::extract_candidates(&eg_allowed, &eg_denote);
 
@@ -518,21 +518,21 @@ mod tests {
         let atoms3 = iter_pos(5);
         // assert_eq!(atoms3.force().len(), 51);
 
-        let rules3 = run_rule_lifting(atoms3, all_rules.clone(), limits, limits);
+        let rules3 = run_fast_forwarding(atoms3, all_rules.clone(), limits, limits);
         // assert_eq!(rules3.len(), 6);
         all_rules.extend(rules3);
 
         let atoms4 = iter_pos(5);
         // assert_eq!(atoms4.force().len(), 255);
 
-        let rules4 = run_rule_lifting(atoms4, all_rules.clone(), limits, limits);
+        let rules4 = run_fast_forwarding(atoms4, all_rules.clone(), limits, limits);
         // assert_eq!(rules4.len(), 2);
         all_rules.extend(rules4);
 
         let atoms5 = iter_pos(5);
         // assert_eq!(atoms5.force().len(), 1527);
 
-        let rules4 = run_rule_lifting(atoms5, all_rules.clone(), limits, limits);
+        let rules4 = run_fast_forwarding(atoms5, all_rules.clone(), limits, limits);
         // assert_eq!(rules4.len(), 1);
     }
 }

--- a/tests/pos.rs
+++ b/tests/pos.rs
@@ -46,11 +46,11 @@ impl Pos {
 impl SynthLanguage for Pos {
     type Constant = usize;
 
-    fn is_rule_lifting() -> bool {
+    fn is_fast_forwarding() -> bool {
         true
     }
 
-    fn get_lifting_rules() -> Ruleset<Self> {
+    fn get_exploratory_rules() -> Ruleset<Self> {
         Ruleset::new(&[
             "XH ==> (S Z)",
             "(S Z) ==> XH",
@@ -113,7 +113,7 @@ impl SynthLanguage for Pos {
 mod tests {
     use ruler::{
         enumo::{Filter, Metric, Ruleset, Scheduler, Workload},
-        recipe_utils::{base_lang, iter_metric, run_rule_lifting},
+        recipe_utils::{base_lang, iter_metric, run_fast_forwarding},
     };
 
     use super::*;
@@ -161,7 +161,7 @@ mod tests {
         let eg_allowed = Scheduler::Compress(limits).run(&eg_init, &allowed);
 
         // Translation rules: grow egraph, extract candidates, assert!(saturated)
-        let lifting_rules = Pos::get_lifting_rules();
+        let lifting_rules = Pos::get_exploratory_rules();
         let eg_denote = Scheduler::Simple(limits).run(&eg_allowed, &lifting_rules);
         let mut candidates = Ruleset::extract_candidates(&eg_allowed, &eg_denote);
 
@@ -205,19 +205,19 @@ mod tests {
         let atoms3 = iter_pos(3);
         assert_eq!(atoms3.force().len(), 51);
 
-        let rules3 = run_rule_lifting(atoms3, all_rules.clone(), limits, limits);
+        let rules3 = run_fast_forwarding(atoms3, all_rules.clone(), limits, limits);
         all_rules.extend(rules3);
 
         let atoms4 = iter_pos(4);
         assert_eq!(atoms4.force().len(), 255);
 
-        let rules4 = run_rule_lifting(atoms4, all_rules.clone(), limits, limits);
+        let rules4 = run_fast_forwarding(atoms4, all_rules.clone(), limits, limits);
         all_rules.extend(rules4);
 
         let atoms5 = iter_pos(5);
         assert_eq!(atoms5.force().len(), 1527);
 
-        let rules4 = run_rule_lifting(atoms5, all_rules.clone(), limits, limits);
+        let rules4 = run_fast_forwarding(atoms5, all_rules.clone(), limits, limits);
         all_rules.extend(rules4);
 
         let expected: Ruleset<Pos> = Ruleset::new(&[

--- a/tests/recipes/exponential.rs
+++ b/tests/recipes/exponential.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::test::{rational_rules, starting_exponential_rules};
-use ruler::{enumo, recipe_utils::run_rule_lifting};
+use ruler::{enumo, recipe_utils::run_fast_forwarding};
 
 type Workload = enumo::Workload;
 type Ruleset = enumo::Ruleset<Exponential>;
@@ -29,7 +29,7 @@ fn constant_rules(prev_rules: &Ruleset) -> Ruleset {
         "(pow 1 a)",
     ]);
 
-    run_rule_lifting(terms, prev_rules.clone(), limits(), limits())
+    run_fast_forwarding(terms, prev_rules.clone(), limits(), limits())
 }
 
 fn exp_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -49,7 +49,7 @@ fn exp_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits(), limits())
+    run_fast_forwarding(upper_layer, prev_rules.clone(), limits(), limits())
 }
 
 fn log_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -69,7 +69,7 @@ fn log_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits(), limits())
+    run_fast_forwarding(upper_layer, prev_rules.clone(), limits(), limits())
 }
 
 fn no_pow_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -95,7 +95,7 @@ fn no_pow_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits(), limits())
+    run_fast_forwarding(upper_layer, prev_rules.clone(), limits(), limits())
 }
 
 fn simple_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -121,7 +121,7 @@ fn simple_rules(prev_rules: &Ruleset) -> Ruleset {
             "(log (log ?a))".parse().unwrap(),
         ))));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits(), limits())
+    run_fast_forwarding(upper_layer, prev_rules.clone(), limits(), limits())
 }
 
 fn div_rules(prev_rules: &Ruleset) -> Ruleset {
@@ -142,7 +142,7 @@ fn div_rules(prev_rules: &Ruleset) -> Ruleset {
         .plug("bop", &bops)
         .filter(Filter::Canon(str_vec!["a", "b"]));
 
-    run_rule_lifting(upper_layer, prev_rules.clone(), limits(), limits())
+    run_fast_forwarding(upper_layer, prev_rules.clone(), limits(), limits())
 }
 
 pub fn make_rules() -> Ruleset {

--- a/tests/recipes/trig.rs
+++ b/tests/recipes/trig.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::test::prior_rules;
 use ruler::{
     enumo::{Filter, Ruleset, Workload},
-    recipe_utils::run_rule_lifting,
+    recipe_utils::run_fast_forwarding,
     Limits,
 };
 
@@ -56,20 +56,20 @@ pub fn trig_rules() -> Ruleset<Trig> {
 
     let wkld1 = trig_constants;
     println!("Starting 1");
-    let rules1 = run_rule_lifting(wkld1.clone(), all.clone(), limits, limits);
+    let rules1 = run_fast_forwarding(wkld1.clone(), all.clone(), limits, limits);
     all.extend(rules1.clone());
     new.extend(rules1.clone());
 
     let wkld2 = Workload::Append(vec![wkld1, simple_terms, neg_terms]);
     println!("Starting 2");
-    let rules2 = run_rule_lifting(wkld2.clone(), all.clone(), limits, limits);
+    let rules2 = run_fast_forwarding(wkld2.clone(), all.clone(), limits, limits);
     all.extend(rules2.clone());
     new.extend(rules2.clone());
 
     let trimmed_wkld2 = wkld2.clone().filter(no_trig_2x);
     let wkld3 = Workload::Append(vec![trimmed_wkld2.clone(), sum_of_squares.clone()]);
     println!("Starting 3");
-    let rules3 = run_rule_lifting(wkld3, all.clone(), limits, limits);
+    let rules3 = run_fast_forwarding(wkld3, all.clone(), limits, limits);
     all.extend(rules3.clone());
     new.extend(rules3.clone());
 
@@ -135,25 +135,25 @@ pub fn trig_rules() -> Ruleset<Trig> {
 
     // Coangles
     let wkld1 = Workload::Append(vec![simple, consts.clone()]);
-    let rules1 = run_rule_lifting(wkld1.clone(), all.clone(), limits, limits);
+    let rules1 = run_fast_forwarding(wkld1.clone(), all.clone(), limits, limits);
     all.extend(rules1.clone());
     new.extend(rules1.clone());
 
     // Power reduction
     let wkld2 = Workload::Append(vec![scaled_shifted_sqrs, consts.clone()]);
-    let rules2 = run_rule_lifting(wkld2.clone(), all.clone(), limits, limits);
+    let rules2 = run_fast_forwarding(wkld2.clone(), all.clone(), limits, limits);
     all.extend(rules2.clone());
     new.extend(rules2.clone());
 
     // Product-to-sum
     let wkld3 = Workload::Append(vec![scaled_sum_prod, consts.clone()]);
-    let rules3 = run_rule_lifting(wkld3.clone(), all.clone(), limits, limits);
+    let rules3 = run_fast_forwarding(wkld3.clone(), all.clone(), limits, limits);
     all.extend(rules3.clone());
     new.extend(rules3.clone());
 
     // Sums
     let wkld4 = Workload::Append(vec![two_var_no_sub, sum_of_prod, consts.clone()]);
-    let rules4 = run_rule_lifting(wkld4.clone(), all.clone(), limits, limits);
+    let rules4 = run_fast_forwarding(wkld4.clone(), all.clone(), limits, limits);
     all.extend(rules4.clone());
     new.extend(rules4.clone());
     new

--- a/tests/szalinski.rs
+++ b/tests/szalinski.rs
@@ -144,11 +144,11 @@ fn is_caddy(node: &CF) -> bool {
 impl SynthLanguage for CF {
     type Constant = Constant;
 
-    fn is_rule_lifting() -> bool {
+    fn is_fast_forwarding() -> bool {
         true
     }
 
-    fn get_lifting_rules() -> Ruleset<Self> {
+    fn get_exploratory_rules() -> Ruleset<Self> {
         Ruleset::new(&get_lifting_rules())
     }
 
@@ -229,7 +229,10 @@ fn export_print(rs: &Ruleset<CF>) {
 
 #[cfg(test)]
 mod tests {
-    use ruler::enumo::{Ruleset, Scheduler, Workload};
+    use ruler::{
+        enumo::{Ruleset, Workload},
+        recipe_utils::run_fast_forwarding,
+    };
 
     use super::*;
 
@@ -272,10 +275,7 @@ mod tests {
 
         for i in 2..4 {
             let atoms = iter_szalinski(i);
-            let egraph = atoms.to_egraph::<CF>();
-            let mut candidates = Ruleset::allow_forbid_actual(egraph, all_rules.clone(), limits);
-            let (chosen, _) =
-                candidates.minimize(learned_rules.clone(), Scheduler::Compress(limits));
+            let chosen = run_fast_forwarding(atoms, all_rules.clone(), limits, limits);
 
             all_rules.extend(chosen.clone());
             learned_rules.extend(chosen);

--- a/tests/trig.rs
+++ b/tests/trig.rs
@@ -148,11 +148,11 @@ egg::define_language! {
 impl SynthLanguage for Trig {
     type Constant = Real;
 
-    fn is_rule_lifting() -> bool {
+    fn is_fast_forwarding() -> bool {
         true
     }
 
-    fn get_lifting_rules() -> Ruleset<Self> {
+    fn get_exploratory_rules() -> Ruleset<Self> {
         Ruleset::new(&[
             // definition of sine, cosine, tangent
             // (sine)
@@ -320,7 +320,7 @@ mod test {
     use crate::trig::trig_rules;
     use ruler::{
         enumo::{Filter, Ruleset, Scheduler, Workload},
-        recipe_utils::run_rule_lifting,
+        recipe_utils::run_fast_forwarding,
         Limits,
     };
 
@@ -390,7 +390,7 @@ mod test {
         let mut all = complex;
         all.extend(prior_rules());
 
-        let rules = run_rule_lifting(terms, all, limits, limits);
+        let rules = run_fast_forwarding(terms, all, limits, limits);
 
         let expected: Ruleset<Trig> =
             Ruleset::new(&["(sin (* PI 2)) <=> 0", "0 <=> (sin 0)", "0 <=> (sin PI)"]);
@@ -453,11 +453,11 @@ mod test {
         };
         let mut all = Ruleset::from_file("scripts/oopsla21/trig/complex.rules");
         all.extend(prior_rules());
-        all.extend(Trig::get_lifting_rules());
+        all.extend(Trig::get_exploratory_rules());
         let mut all_but_exploratory = all.clone();
-        all_but_exploratory.remove_all(Trig::get_lifting_rules());
+        all_but_exploratory.remove_all(Trig::get_exploratory_rules());
         let (allowed, _) = all.partition(|r| Trig::is_allowed_rewrite(&r.lhs, &r.rhs));
-        let exploratory = Trig::get_lifting_rules();
+        let exploratory = Trig::get_exploratory_rules();
 
         let lits = Workload::new([
             "a", "b", "c", "0", "(/ PI 6)", "(/ PI 4)", "(/ PI 3)", "(/ PI 2)", "PI", "(* PI 2)",

--- a/tests/trig.rs
+++ b/tests/trig.rs
@@ -434,7 +434,7 @@ mod test {
         // let (sound, _) = candidates.partition(|r| r.is_valid());
         let (sound, _) = candidates.minimize(minimize.rules, minimize.scheduler);
 
-        logger::write_lifting_phase(phase1, phase2, phase3, start.elapsed(), &sound);
+        logger::write_ff_phase(phase1, phase2, phase3, start.elapsed(), &sound);
 
         (sound, start.elapsed())
     }


### PR DESCRIPTION
Now that the paper is done and everything is settled, we should remove references to "lifting", "allow/forbid", etc and call everything fast-forwarding