### PR TITLE
Cleanup the trig recipe

### DIFF
--- a/tests/recipes/trig.rs
+++ b/tests/recipes/trig.rs
@@ -6,72 +6,146 @@ use ruler::{
     Limits,
 };
 
+/// Terms that apply trigonometric functions to (possibly fractional)
+/// multiples of pi.
+fn workload_consts() -> Workload {
+    let op = Workload::new(["sin", "cos", "tan"]);
+    let cnst = Workload::new([
+        "0", "(/ PI 6)", "(/ PI 4)", "(/ PI 3)", "(/ PI 2)", "PI", "(* PI 2)",
+    ]);
+
+    let invalid = Filter::Contains(
+        "(tan (/ PI 2))".parse().unwrap(),
+    );
+
+    Workload::new(["(op v)"])
+        .plug("op", &op)
+        .plug("v", &cnst)
+        .filter(Filter::Invert(Box::new(invalid)))
+}
+
+/// Terms that apply trigonometric functions to a variable,
+/// possibly translated by a negation or ±pi; terms may also
+/// be negated.
+fn workload_symmetry_periodicity() -> Workload {
+    let op = Workload::new(["sin", "cos", "tan"]);
+    let var = Workload::new(["a"]);
+
+    let t_shift = Workload::new(["x", "(~ x)", "(+ PI x)", "(- PI x)", "(+ x x)"]).plug("x", &var);
+    let t_simpl = Workload::new(["(op t)"]).plug("op", &op).plug("t", &t_shift);
+    let t_neg = Workload::new(["(~ t)"]).plug("t", &t_simpl);
+
+    workload_consts().append(t_simpl).append(t_neg)
+}
+
+/// Terms to prove identitites that sum-of-squares terms, e.g.,
+/// sin(x) * sin(x). This includes the Pythagorean identity.
+fn workload_sum_of_squares() -> Workload {
+    let op = Workload::new(["sin", "cos", "tan"]);
+    let var = Workload::new(["a", "b"]);
+
+    let double_angle = Filter::Or(vec![
+        Filter::Contains("(sin (+ ?a ?a))".parse().unwrap()),
+        Filter::Contains("(cos (+ ?a ?a))".parse().unwrap()),
+        Filter::Contains("(tan (+ ?a ?a))".parse().unwrap()),
+    ]);
+
+    let t_simpl = Workload::new(["(op t)"]).plug("op", &op).plug("t", &var);
+    let t_sqr = Workload::new(["(* t t)"]).plug("t", &t_simpl);
+    let t_sos = Workload::new(["(+ t t)", "(- t t)"]).plug("t", &t_sqr);
+
+    workload_symmetry_periodicity()
+        .filter(Filter::Invert(Box::new(double_angle)))
+        .append(t_sos)
+}
+
+/// Terms to prove co-angle identities, e.g., (cos x) => (sin (- (/ PI 2) x))
+fn workload_coangle() -> Workload {
+    let op = Workload::new(["sin", "cos", "tan"]);
+    let var = Workload::new(["a", "b"]);
+    let cnst = Workload::new([
+        "0", "(/ PI 6)", "(/ PI 4)", "(/ PI 3)", "(/ PI 2)", "PI", "(* PI 2)",
+    ]);
+
+    let t_shift = Workload::new(["x", "(~ x)", "(+ PI x)", "(- PI x)", "(+ x x)"]).plug("x", &var);
+    let t_simpl = Workload::new(["(op t)"]).plug("op", &op).plug("t", &t_shift);
+
+    t_simpl.append(cnst)
+}
+
+/// Terms to prove power reduction identities, e.g.,
+/// (* (cos x) (cos x)) => (1 - (sin x) * (sin x)).
+// fn workload_power_reduction() -> Workload {
+//     let op = Workload::new(["sin", "cos", "tan"]);
+//     let var = Workload::new(["a", "b"]);
+//     let cnst = Workload::new([
+//         "0", "(/ PI 6)", "(/ PI 4)", "(/ PI 3)", "(/ PI 2)", "PI", "(* PI 2)",
+//     ]);
+
+//     let t_xform = Workload::new(["a", "(- a)", "(+ x)", "(+ (/ PI 2) x)", "(* 2 x)"]).plug("x", &var);
+    
+// }
+
+
 pub fn trig_rules() -> Ruleset<Trig> {
     let limits = Limits {
         iter: 3,
         node: 2000000,
         match_: 200_000,
     };
+
+    // known rules for fast-fowarding
     let mut prior: Ruleset<Trig> = Ruleset::from_file("scripts/oopsla21/trig/complex.rules");
     prior.extend(prior_rules());
 
-    let no_trig_2x = Filter::Invert(Box::new(Filter::Or(vec![
-        Filter::Contains("(sin (+ ?a ?a))".parse().unwrap()),
-        Filter::Contains("(cos (+ ?a ?a))".parse().unwrap()),
-        Filter::Contains("(tan (+ ?a ?a))".parse().unwrap()),
-    ])));
-    let valid_trig = Filter::Invert(Box::new(Filter::Contains(
-        "(tan (/ PI 2))".parse().unwrap(),
-    )));
-
-    let t_ops = Workload::new(["sin", "cos", "tan"]);
-    let consts = Workload::new([
-        "0", "(/ PI 6)", "(/ PI 4)", "(/ PI 3)", "(/ PI 2)", "PI", "(* PI 2)",
-    ]);
-    let app = Workload::new(["(op v)"]);
-    let trig_constants = app
-        .clone()
-        .plug("op", &t_ops)
-        .plug("v", &consts)
-        .filter(valid_trig);
-
-    let simple_terms = app.clone().plug("op", &t_ops).plug(
-        "v",
-        &Workload::new(["a", "(~ a)", "(+ PI a)", "(- PI a)", "(+ a a)"]),
-    );
-
-    let neg_terms = Workload::new(["(~ x)"]).plug("x", &simple_terms);
-
-    let squares = Workload::new(["(sqr x)"])
-        .plug("x", &app)
-        .plug("op", &t_ops)
-        .plug("v", &Workload::new(["a", "b"]));
-
-    let add = Workload::new(["(+ e e)", "(- e e)"]);
-
-    let sum_of_squares = add.plug("e", &squares);
-
+    // rulesets
     let mut all = prior.clone();
     let mut new = Ruleset::<Trig>::default();
 
-    let wkld1 = trig_constants;
+    /////////////////////////////////////////////////////////////////
+    // workload 1: constants
     println!("Starting 1");
-    let rules1 = run_fast_forwarding(wkld1.clone(), all.clone(), limits, limits);
-    all.extend(rules1.clone());
-    new.extend(rules1.clone());
+    let wkld_consts = workload_consts();
+    let rules = run_fast_forwarding(wkld_consts.clone(), all.clone(), limits, limits);
+    all.extend(rules.clone());
+    new.extend(rules.clone());
 
-    let wkld2 = Workload::Append(vec![wkld1, simple_terms, neg_terms]);
+    /////////////////////////////////////////////////////////////////
+    // workload 2: even/odd symmetry and periodicity
     println!("Starting 2");
-    let rules2 = run_fast_forwarding(wkld2.clone(), all.clone(), limits, limits);
-    all.extend(rules2.clone());
-    new.extend(rules2.clone());
-
-    let trimmed_wkld2 = wkld2.clone().filter(no_trig_2x);
-    let wkld3 = Workload::Append(vec![trimmed_wkld2.clone(), sum_of_squares.clone()]);
+    let wkld_sym_per = workload_symmetry_periodicity();
+    let rules = run_fast_forwarding(wkld_sym_per.clone(), all.clone(), limits, limits);
+    all.extend(rules.clone());
+    new.extend(rules.clone());
+    
+    /////////////////////////////////////////////////////////////////
+    // workload 3: sum of squares
     println!("Starting 3");
-    let rules3 = run_fast_forwarding(wkld3, all.clone(), limits, limits);
-    all.extend(rules3.clone());
-    new.extend(rules3.clone());
+    let wkld_sos = workload_sum_of_squares();
+    let rules = run_fast_forwarding(wkld_sos, all.clone(), limits, limits);
+    all.extend(rules.clone());
+    new.extend(rules.clone());
+
+    /////////////////////////////////////////////////////////////////
+    // workload 4: coangles
+    println!("Starting 4");
+    let wkld_coangle = workload_coangle();
+    let rules = run_fast_forwarding(wkld_coangle, all.clone(), limits, limits);
+    all.extend(rules.clone());
+    new.extend(rules.clone());
+
+    /////////////////////////////////////////////////////////////////
+    // workload 5: power reduction
+    println!("Starting 5");
+
+    /////////////////////////////////////////////////////////////////
+    // workload 6: product-to-sum reduction
+    println!("Starting 6");
+
+    /////////////////////////////////////////////////////////////////
+    // workload 7: sum-to-product reduction
+    println!("Starting 7");
+
 
     let non_square_filter = Filter::Invert(Box::new(Filter::Or(vec![
         Filter::Contains("(* (cos ?x) (cos ?x))".parse().unwrap()),
@@ -132,12 +206,6 @@ pub fn trig_rules() -> Ruleset<Trig> {
     let scaled_sum_prod = scale_down.clone().plug("x", &sum_and_prod);
 
     let two_var_no_sub = two_var.clone().filter(trig_no_sub_filter);
-
-    // Coangles
-    let wkld1 = Workload::Append(vec![simple, consts.clone()]);
-    let rules1 = run_fast_forwarding(wkld1.clone(), all.clone(), limits, limits);
-    all.extend(rules1.clone());
-    new.extend(rules1.clone());
 
     // Power reduction
     let wkld2 = Workload::Append(vec![scaled_shifted_sqrs, consts.clone()]);

--- a/tests/recipes/trig.rs
+++ b/tests/recipes/trig.rs
@@ -168,14 +168,14 @@ fn workload_sum_to_product() -> Workload {
 
     // product of trig functions (no squares)
     let t_prod = Workload::new(["(* t1 t2)"])
-        .plug("t", &t_2var)
         .plug("t1", &t_2var)
+        .plug("t2", &t_2var)
         .filter(Filter::Invert(Box::new(is_square)));
 
     // sum-of-product terms
     let t_sop = Workload::new(["(+ t1 t2)", "(- t1 t2)"])
         .plug("t1", &t_prod)
-        .plug("t2", &t_2var)
+        .plug("t2", &t_prod)
         .filter(Filter::Invert(Box::new(is_double)))
         .filter(Filter::Invert(Box::new(is_nontrivial)));
 

--- a/tests/recipes/trig.rs
+++ b/tests/recipes/trig.rs
@@ -14,9 +14,7 @@ fn workload_consts() -> Workload {
         "0", "(/ PI 6)", "(/ PI 4)", "(/ PI 3)", "(/ PI 2)", "PI", "(* PI 2)",
     ]);
 
-    let invalid = Filter::Contains(
-        "(tan (/ PI 2))".parse().unwrap(),
-    );
+    let invalid = Filter::Contains("(tan (/ PI 2))".parse().unwrap());
 
     Workload::new(["(op v)"])
         .plug("op", &op)
@@ -34,7 +32,9 @@ fn workload_symmetry_periodicity() -> Workload {
     // shift argument to function
     // (and optionally) negate it
     let t_shift = Workload::new(["t", "(~ t)", "(+ PI t)", "(- PI t)", "(+ t t)"]).plug("t", &var);
-    let t_simpl = Workload::new(["(op t)"]).plug("op", &op).plug("t", &t_shift);
+    let t_simpl = Workload::new(["(op t)"])
+        .plug("op", &op)
+        .plug("t", &t_shift);
     let t_neg = Workload::new(["(~ t)"]).plug("t", &t_simpl);
 
     workload_consts().append(t_simpl).append(t_neg)
@@ -68,8 +68,11 @@ fn workload_coangle() -> Workload {
     let var = Workload::new(["a", "b"]);
     let cnst = Workload::new(["-2", "-1", "0", "1", "2"]);
 
-    let t_shift = Workload::new(["t", "(- (/ PI 2) t)", "(+ (/ PI 2) t)", "(* 2 t)"]).plug("t", &var);
-    let t_simpl = Workload::new(["(op t)"]).plug("op", &op).plug("t", &t_shift);
+    let t_shift =
+        Workload::new(["t", "(- (/ PI 2) t)", "(+ (/ PI 2) t)", "(* 2 t)"]).plug("t", &var);
+    let t_simpl = Workload::new(["(op t)"])
+        .plug("op", &op)
+        .plug("t", &t_shift);
 
     t_simpl.append(cnst)
 }
@@ -86,8 +89,11 @@ fn workload_power_reduction() -> Workload {
     let t_sqr = Workload::new(["(sqr t)"]).plug("t", &t_trig);
 
     // trig functions (with possibly shifted arguments, and shifted output)
-    let t_xform = Workload::new(["t", "(- (/ PI 2) t)", "(+ (/ PI 2) t)", "(* 2 t)"]).plug("t", &var);
-    let t_trig_xform = Workload::new(["(op t)"]).plug("op", &op).plug("t", &t_xform);
+    let t_xform =
+        Workload::new(["t", "(- (/ PI 2) t)", "(+ (/ PI 2) t)", "(* 2 t)"]).plug("t", &var);
+    let t_trig_xform = Workload::new(["(op t)"])
+        .plug("op", &op)
+        .plug("t", &t_xform);
     let t_shift = Workload::new(["t", "(- 1 t)", "(+ 1 t)"]).plug("t", &t_trig_xform);
 
     // merge and scale
@@ -113,7 +119,9 @@ fn workload_product_to_sum() -> Workload {
     let t_simpl = Workload::new(["a", "b", "(+ a b)", "(- a b)"]);
 
     // trig functions with variable arguments
-    let t_2var = Workload::new(["(op t)"]).plug("op", &op).plug("t", &t_simpl);
+    let t_2var = Workload::new(["(op t)"])
+        .plug("op", &op)
+        .plug("t", &t_simpl);
 
     // product of trig functions (no squares)
     let t_prod = Workload::new(["(* t1 t2)"])
@@ -164,7 +172,9 @@ fn workload_sum_to_product() -> Workload {
     let t_simpl = Workload::new(["a", "b", "(+ a b)", "(- a b)"]);
 
     // trig functions with variable arguments
-    let t_2var = Workload::new(["(op t)"]).plug("op", &op).plug("t", &t_simpl);
+    let t_2var = Workload::new(["(op t)"])
+        .plug("op", &op)
+        .plug("t", &t_simpl);
 
     // product of trig functions (no squares)
     let t_prod = Workload::new(["(* t1 t2)"])
@@ -182,11 +192,8 @@ fn workload_sum_to_product() -> Workload {
     // remove difference of angles
     let t_2var_no_sub = t_2var.filter(Filter::Invert(Box::new(is_diff)));
 
-    t_2var_no_sub
-        .append(t_sop)
-        .append(cnst)
+    t_2var_no_sub.append(t_sop).append(cnst)
 }
-
 
 pub fn trig_rules() -> Ruleset<Trig> {
     let limits = Limits {
@@ -218,7 +225,7 @@ pub fn trig_rules() -> Ruleset<Trig> {
     let rules = run_fast_forwarding(wkld_sym_per.clone(), all.clone(), limits, limits);
     all.extend(rules.clone());
     new.extend(rules.clone());
-    
+
     /////////////////////////////////////////////////////////////////
     // workload 3: sum of squares
     println!("starting 3: sum of squares");
@@ -258,7 +265,6 @@ pub fn trig_rules() -> Ruleset<Trig> {
     let rules = run_fast_forwarding(wkld_sum_prod, all.clone(), limits, limits);
     all.extend(rules.clone());
     new.extend(rules.clone());
-
 
     new
 }


### PR DESCRIPTION
Cleans up the trig recipe by separating each workload into a separate function, restructuring some workloads, and adding some documentation. Tested by manual comparison of the generated identities and checking that the workload sizes are the same.