### PR TITLE
Upgrade z3 0.12.1 → 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ float-cmp = "0.8.0"
 lazy_static = "1.4.0"
 itertools = "0.9.0"
 # fixed = "1.9.0"
-#z3 = "0.12.1"
-z3 = {version = "0.12.1", features = ["static-link-z3"]}
+z3 = {version = "0.20", features = ["bundled"]}
 rustc-hash = "1"
 symbolic_expressions = "5"
 rayon = "1"

--- a/src/bv.rs
+++ b/src/bv.rs
@@ -245,12 +245,12 @@ macro_rules! impl_bv {
             ) -> ValidationResult {
                 use z3::{*, ast::Ast};
 
-                fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Bv]) -> z3::ast::BV<'a> {
+                fn egg_to_z3(expr: &[Bv]) -> z3::ast::BV {
                     let mut buf: Vec<z3::ast::BV> = vec![];
                     for node in expr.as_ref().iter() {
                         match node {
-                            Bv::Var(v) => buf.push(z3::ast::BV::new_const(&ctx, v.to_string(), $n)),
-                            Bv::Lit(c) => buf.push(z3::ast::BV::from_u64(&ctx, c.0 as u64, $n)),
+                            Bv::Var(v) => buf.push(z3::ast::BV::new_const(v.to_string(), $n)),
+                            Bv::Lit(c) => buf.push(z3::ast::BV::from_u64(c.0 as u64, $n)),
                             Bv::Add([a, b]) => buf.push(buf[usize::from(*a)].bvadd(&buf[usize::from(*b)])),
                             Bv::Sub([a, b]) => buf.push(buf[usize::from(*a)].bvsub(&buf[usize::from(*b)])),
                             Bv::Mul([a, b]) => buf.push(buf[usize::from(*a)].bvmul(&buf[usize::from(*b)])),
@@ -268,16 +268,17 @@ macro_rules! impl_bv {
 
                 let mut cfg = z3::Config::new();
                 cfg.set_timeout_msec(1000);
-                let ctx = z3::Context::new(&cfg);
-                let solver = z3::Solver::new(&ctx);
-                let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
-                let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
-                solver.assert(&lexpr._eq(&rexpr).not());
-                match solver.check() {
-                    SatResult::Sat => ValidationResult::Invalid,
-                    SatResult::Unsat => ValidationResult::Valid,
-                    SatResult::Unknown => ValidationResult::Unknown
-                }
+                z3::with_z3_config(&cfg, || {
+                    let solver = z3::Solver::new();
+                    let lexpr = egg_to_z3(Self::instantiate(lhs).as_ref());
+                    let rexpr = egg_to_z3(Self::instantiate(rhs).as_ref());
+                    solver.assert(&lexpr.eq(&rexpr).not());
+                    match solver.check() {
+                        SatResult::Sat => ValidationResult::Invalid,
+                        SatResult::Unsat => ValidationResult::Valid,
+                        SatResult::Unknown => ValidationResult::Unknown
+                    }
+                })
             }
         }
     };

--- a/src/enumo/ruleset.rs
+++ b/src/enumo/ruleset.rs
@@ -182,8 +182,22 @@ impl<L: SynthLanguage> Ruleset<L> {
     pub fn to_file(&self, filename: &str) {
         let mut file = std::fs::File::create(filename)
             .unwrap_or_else(|_| panic!("Failed to open '{}'", filename));
-        for (name, _) in &self.0 {
-            writeln!(file, "{}", name).expect("Unable to write");
+
+        let mut strs = vec![];
+        for (name, rule) in &self.0 {
+            let reverse = Rule::new(&rule.rhs, &rule.lhs);
+            if reverse.is_some() && self.contains(&reverse.unwrap()) {
+                let reverse_name = format!("{} <=> {}", rule.rhs, rule.lhs);
+                if !strs.contains(&reverse_name) {
+                    strs.push(format!("{} <=> {}", rule.lhs, rule.rhs));
+                }
+            } else {
+                strs.push(name.to_string());
+            }
+        }
+
+        for s in strs {
+            writeln!(file, "{}", s).expect("Unable to write");
         }
     }
 

--- a/tests/halide.rs
+++ b/tests/halide.rs
@@ -147,135 +147,112 @@ impl SynthLanguage for Pred {
     fn validate(lhs: &Pattern<Self>, rhs: &Pattern<Self>) -> ValidationResult {
         let mut cfg = z3::Config::new();
         cfg.set_timeout_msec(1000);
-        let ctx = z3::Context::new(&cfg);
-        let solver = z3::Solver::new(&ctx);
-        let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
-        let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
-        solver.assert(&lexpr._eq(&rexpr).not());
-        match solver.check() {
-            z3::SatResult::Unsat => ValidationResult::Valid,
-            z3::SatResult::Unknown => ValidationResult::Unknown,
-            z3::SatResult::Sat => ValidationResult::Invalid,
-        }
+        z3::with_z3_config(&cfg, || {
+            let solver = z3::Solver::new();
+            let lexpr = egg_to_z3(Self::instantiate(lhs).as_ref());
+            let rexpr = egg_to_z3(Self::instantiate(rhs).as_ref());
+            solver.assert(&lexpr.eq(&rexpr).not());
+            match solver.check() {
+                z3::SatResult::Unsat => ValidationResult::Valid,
+                z3::SatResult::Unknown => ValidationResult::Unknown,
+                z3::SatResult::Sat => ValidationResult::Invalid,
+            }
+        })
     }
 }
 
-fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Pred]) -> z3::ast::Int<'a> {
+fn egg_to_z3(expr: &[Pred]) -> z3::ast::Int {
     let mut buf: Vec<z3::ast::Int> = vec![];
-    let zero = z3::ast::Int::from_i64(ctx, 0);
-    let one = z3::ast::Int::from_i64(ctx, 1);
+    let zero = z3::ast::Int::from_i64(0);
+    let one = z3::ast::Int::from_i64(1);
     for node in expr.as_ref().iter() {
         match node {
-            Pred::Lit(c) => buf.push(z3::ast::Int::from_i64(ctx, c.to_i64().unwrap())),
+            Pred::Lit(c) => buf.push(z3::ast::Int::from_i64(c.to_i64().unwrap())),
             Pred::Lt([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                buf.push(z3::ast::Bool::ite(&z3::ast::Int::lt(l, r), &one, &zero))
+                buf.push(l.lt(r).ite(&one, &zero))
             }
             Pred::Leq([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                buf.push(z3::ast::Bool::ite(&z3::ast::Int::le(l, r), &one, &zero))
+                buf.push(l.le(r).ite(&one, &zero))
             }
             Pred::Eq([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                buf.push(z3::ast::Bool::ite(&z3::ast::Int::_eq(l, r), &one, &zero))
+                buf.push(l.eq(r).ite(&one, &zero))
             }
             Pred::Neq([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                buf.push(z3::ast::Bool::ite(&z3::ast::Int::_eq(l, r), &zero, &one))
+                buf.push(l.eq(r).ite(&zero, &one))
             }
             Pred::Implies([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                let l_not_z = z3::ast::Bool::not(&l._eq(&zero));
-                let r_not_z = z3::ast::Bool::not(&r._eq(&zero));
-                buf.push(z3::ast::Bool::ite(
-                    &z3::ast::Bool::implies(&l_not_z, &r_not_z),
-                    &one,
-                    &zero,
-                ))
+                let l_not_z = l.eq(&zero).not();
+                let r_not_z = r.eq(&zero).not();
+                buf.push(l_not_z.implies(&r_not_z).ite(&one, &zero))
             }
             Pred::Not(x) => {
                 let l = &buf[usize::from(*x)];
-                buf.push(z3::ast::Bool::ite(&l._eq(&zero), &one, &zero))
+                buf.push(l.eq(&zero).ite(&one, &zero))
             }
-            Pred::Neg(x) => buf.push(z3::ast::Int::unary_minus(&buf[usize::from(*x)])),
+            Pred::Neg(x) => buf.push(buf[usize::from(*x)].unary_minus()),
             Pred::And([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                let l_not_z = z3::ast::Bool::not(&l._eq(&zero));
-                let r_not_z = z3::ast::Bool::not(&r._eq(&zero));
-                buf.push(z3::ast::Bool::ite(
-                    &z3::ast::Bool::and(ctx, &[&l_not_z, &r_not_z]),
-                    &one,
-                    &zero,
-                ))
+                let l_not_z = l.eq(&zero).not();
+                let r_not_z = r.eq(&zero).not();
+                buf.push(z3::ast::Bool::and(&[l_not_z, r_not_z]).ite(&one, &zero))
             }
             Pred::Or([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                let l_not_z = z3::ast::Bool::not(&l._eq(&zero));
-                let r_not_z = z3::ast::Bool::not(&r._eq(&zero));
-                buf.push(z3::ast::Bool::ite(
-                    &z3::ast::Bool::or(ctx, &[&l_not_z, &r_not_z]),
-                    &one,
-                    &zero,
-                ))
+                let l_not_z = l.eq(&zero).not();
+                let r_not_z = r.eq(&zero).not();
+                buf.push(z3::ast::Bool::or(&[l_not_z, r_not_z]).ite(&one, &zero))
             }
             Pred::Xor([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                let l_not_z = z3::ast::Bool::not(&l._eq(&zero));
-                let r_not_z = z3::ast::Bool::not(&r._eq(&zero));
-                buf.push(z3::ast::Bool::ite(
-                    &z3::ast::Bool::xor(&l_not_z, &r_not_z),
-                    &one,
-                    &zero,
-                ))
+                let l_not_z = l.eq(&zero).not();
+                let r_not_z = r.eq(&zero).not();
+                buf.push(l_not_z.xor(&r_not_z).ite(&one, &zero))
             }
-            Pred::Add([x, y]) => buf.push(z3::ast::Int::add(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
-            Pred::Sub([x, y]) => buf.push(z3::ast::Int::sub(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
-            Pred::Mul([x, y]) => buf.push(z3::ast::Int::mul(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
+            Pred::Add([x, y]) => buf.push(z3::ast::Int::add(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
+            Pred::Sub([x, y]) => buf.push(z3::ast::Int::sub(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
+            Pred::Mul([x, y]) => buf.push(z3::ast::Int::mul(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
             Pred::Div([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                buf.push(z3::ast::Bool::ite(
-                    &r._eq(&zero),
-                    &zero,
-                    &z3::ast::Int::div(l, r),
-                ))
+                buf.push(r.eq(&zero).ite(&zero, &l.div(r)))
             }
             Pred::Min([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                buf.push(z3::ast::Bool::ite(&z3::ast::Int::le(l, r), l, r))
+                buf.push(l.le(r).ite(l, r))
             }
             Pred::Max([x, y]) => {
                 let l = &buf[usize::from(*x)];
                 let r = &buf[usize::from(*y)];
-                buf.push(z3::ast::Bool::ite(&z3::ast::Int::le(l, r), r, l))
+                buf.push(l.le(r).ite(r, l))
             }
             Pred::Select([x, y, z]) => {
-                let cond = z3::ast::Bool::not(&buf[usize::from(*x)]._eq(&zero));
-                buf.push(z3::ast::Bool::ite(
-                    &cond,
-                    &buf[usize::from(*y)],
-                    &buf[usize::from(*z)],
-                ))
+                let cond = buf[usize::from(*x)].eq(&zero).not();
+                buf.push(cond.ite(&buf[usize::from(*y)], &buf[usize::from(*z)]))
             }
-            Pred::Var(v) => buf.push(z3::ast::Int::new_const(ctx, v.to_string())),
+            Pred::Var(v) => buf.push(z3::ast::Int::new_const(v.to_string())),
         }
     }
     buf.pop().unwrap()

--- a/tests/halide.rs
+++ b/tests/halide.rs
@@ -1,6 +1,5 @@
 use num::{ToPrimitive, Zero};
 use ruler::*;
-use z3::ast::Ast;
 
 type Constant = i64;
 

--- a/tests/nat.rs
+++ b/tests/nat.rs
@@ -157,7 +157,10 @@ fn egg_to_z3(expr: &[Nat]) -> z3::ast::Int {
     for node in expr.as_ref().iter() {
         match node {
             Nat::Z => buf.push(zero.clone()),
-            Nat::S(x) => buf.push(z3::ast::Int::add(&[buf[usize::from(*x)].clone(), one.clone()])),
+            Nat::S(x) => buf.push(z3::ast::Int::add(&[
+                buf[usize::from(*x)].clone(),
+                one.clone(),
+            ])),
             Nat::Add([x, y]) => buf.push(z3::ast::Int::add(&[
                 buf[usize::from(*x)].clone(),
                 buf[usize::from(*y)].clone(),

--- a/tests/nat.rs
+++ b/tests/nat.rs
@@ -3,7 +3,6 @@ use num_bigint::ToBigInt;
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64;
 use ruler::*;
-use z3::ast::Ast;
 
 egg::define_language! {
   pub enum Nat {

--- a/tests/nat.rs
+++ b/tests/nat.rs
@@ -136,36 +136,37 @@ impl SynthLanguage for Nat {
     fn validate(lhs: &Pattern<Self>, rhs: &Pattern<Self>) -> ValidationResult {
         let mut cfg = z3::Config::new();
         cfg.set_timeout_msec(1000);
-        let ctx = z3::Context::new(&cfg);
-        let solver = z3::Solver::new(&ctx);
-        let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
-        let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
-        solver.assert(&lexpr._eq(&rexpr).not());
-        match solver.check() {
-            z3::SatResult::Unsat => ValidationResult::Valid,
-            z3::SatResult::Unknown => ValidationResult::Unknown,
-            z3::SatResult::Sat => ValidationResult::Invalid,
-        }
+        z3::with_z3_config(&cfg, || {
+            let solver = z3::Solver::new();
+            let lexpr = egg_to_z3(Self::instantiate(lhs).as_ref());
+            let rexpr = egg_to_z3(Self::instantiate(rhs).as_ref());
+            solver.assert(&lexpr.eq(&rexpr).not());
+            match solver.check() {
+                z3::SatResult::Unsat => ValidationResult::Valid,
+                z3::SatResult::Unknown => ValidationResult::Unknown,
+                z3::SatResult::Sat => ValidationResult::Invalid,
+            }
+        })
     }
 }
 
-fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Nat]) -> z3::ast::Int<'a> {
+fn egg_to_z3(expr: &[Nat]) -> z3::ast::Int {
     let mut buf = vec![];
-    let zero = z3::ast::Int::from_i64(ctx, 0);
-    let one = z3::ast::Int::from_i64(ctx, 1);
+    let zero = z3::ast::Int::from_i64(0);
+    let one = z3::ast::Int::from_i64(1);
     for node in expr.as_ref().iter() {
         match node {
             Nat::Z => buf.push(zero.clone()),
-            Nat::S(x) => buf.push(z3::ast::Int::add(ctx, &[&buf[usize::from(*x)], &one])),
-            Nat::Add([x, y]) => buf.push(z3::ast::Int::add(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
-            Nat::Mul([x, y]) => buf.push(z3::ast::Int::mul(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
-            Nat::Var(v) => buf.push(z3::ast::Int::new_const(ctx, v.to_string())),
+            Nat::S(x) => buf.push(z3::ast::Int::add(&[buf[usize::from(*x)].clone(), one.clone()])),
+            Nat::Add([x, y]) => buf.push(z3::ast::Int::add(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
+            Nat::Mul([x, y]) => buf.push(z3::ast::Int::mul(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
+            Nat::Var(v) => buf.push(z3::ast::Int::new_const(v.to_string())),
         }
     }
     buf.pop().unwrap()

--- a/tests/rational.rs
+++ b/tests/rational.rs
@@ -9,7 +9,6 @@ use ruler::{
 use std::{ops::*, time::Instant};
 use symbolic_expressions::parser::parse_str;
 use symbolic_expressions::Sexp;
-use z3::ast::Ast;
 #[path = "./recipes/rational_best.rs"]
 pub mod rational_best;
 #[path = "./recipes/rational_replicate.rs"]
@@ -203,7 +202,7 @@ impl SynthLanguage for Math {
 
 impl Math {
     fn _one_of_errors(denoms: HashSet<String>) -> z3::ast::Bool {
-        let zero_z3 = z3::ast::Real::from_real(0, 1);
+        let zero_z3 = z3::ast::Real::from_rational(0, 1);
 
         let mut one_of_rhs_errors = z3::ast::Bool::from_bool(false);
         for d in denoms {
@@ -320,7 +319,7 @@ impl Math {
                         Self::instantiate(&denom.to_string().parse::<Pattern<Math>>().unwrap())
                             .as_ref(),
                     );
-                    let is_zero = expr.eq(&z3::ast::Real::from_real(0, 1));
+                    let is_zero = expr.eq(&z3::ast::Real::from_rational(0, 1));
 
                     res.push(z3::ast::Bool::and(&[is_zero, path.clone()]));
                 }
@@ -330,7 +329,7 @@ impl Math {
                         Self::instantiate(&list[1].to_string().parse::<Pattern<Math>>().unwrap())
                             .as_ref(),
                     );
-                    let zero = z3::ast::Real::from_real(0, 1);
+                    let zero = z3::ast::Real::from_rational(0, 1);
                     let new_path_pos =
                         z3::ast::Bool::and(&[path.clone(), cond_real.eq(&zero).not()]);
                     let new_path_neg = z3::ast::Bool::and(&[path.clone(), cond_real.eq(&zero)]);
@@ -440,16 +439,16 @@ fn egg_to_z3(expr: &[Math]) -> z3::ast::Real {
             Math::Neg(x) => buf.push(buf[usize::from(*x)].unary_minus()),
             Math::Abs(a) => {
                 let inner = buf[usize::from(*a)].clone();
-                let zero = z3::ast::Real::from_real(0, 1);
+                let zero = z3::ast::Real::from_rational(0, 1);
                 buf.push(inner.le(&zero).ite(&inner.unary_minus(), &inner));
             }
-            Math::Lit(c) => buf.push(z3::ast::Real::from_real(
-                (c.numer()).to_i32().unwrap(),
-                (c.denom()).to_i32().unwrap(),
+            Math::Lit(c) => buf.push(z3::ast::Real::from_rational(
+                (c.numer()).to_i64().unwrap(),
+                (c.denom()).to_i64().unwrap(),
             )),
             Math::Var(v) => buf.push(z3::ast::Real::new_const(v.to_string())),
             Math::If([x, y, z]) => {
-                let zero = z3::ast::Real::from_real(0, 1);
+                let zero = z3::ast::Real::from_rational(0, 1);
                 let cond = buf[usize::from(*x)].eq(&zero).not();
                 buf.push(cond.ite(&buf[usize::from(*y)], &buf[usize::from(*z)]))
             }
@@ -762,6 +761,12 @@ pub mod test {
     #[test]
     fn just_best() {
         best_enumo_recipe();
+    }
+
+    #[test]
+    fn replicate_ruler1() {
+        let rules = replicate_ruler1_recipe();
+        rules.to_file("out/rational.rules");
     }
 
     #[test]

--- a/tests/rational.rs
+++ b/tests/rational.rs
@@ -167,41 +167,33 @@ impl SynthLanguage for Math {
 
         let mut cfg = z3::Config::new();
         cfg.set_timeout_msec(1000);
-        let ctx = z3::Context::new(&cfg);
-        let solver = z3::Solver::new(&ctx);
-        let lexpr = egg_to_z3(&ctx, Self::instantiate(lhs).as_ref());
-        let rexpr = egg_to_z3(&ctx, Self::instantiate(rhs).as_ref());
-        let lhs_denom = Self::error_conditions(
-            &ctx,
-            Self::pat_to_sexp(lhs),
-            z3::ast::Bool::from_bool(&ctx, true),
-        );
-        let rhs_denom = Self::error_conditions(
-            &ctx,
-            Self::pat_to_sexp(rhs),
-            z3::ast::Bool::from_bool(&ctx, true),
-        );
+        z3::with_z3_config(&cfg, || {
+            let solver = z3::Solver::new();
+            let lexpr = egg_to_z3(Self::instantiate(lhs).as_ref());
+            let rexpr = egg_to_z3(Self::instantiate(rhs).as_ref());
+            let lhs_denom = Self::error_conditions(
+                Self::pat_to_sexp(lhs),
+                z3::ast::Bool::from_bool(true),
+            );
+            let rhs_denom = Self::error_conditions(
+                Self::pat_to_sexp(rhs),
+                z3::ast::Bool::from_bool(true),
+            );
 
-        let mut assert_equal = lexpr._eq(&rexpr);
+            let mut assert_equal = lexpr.eq(&rexpr);
 
-        for condition in lhs_denom.iter().chain(rhs_denom.iter()) {
-            assert_equal = condition.not().implies(&assert_equal);
-        }
+            for condition in lhs_denom.iter().chain(rhs_denom.iter()) {
+                assert_equal = condition.not().implies(&assert_equal);
+            }
 
-        let rhs_errors =
-            z3::ast::Bool::or(&ctx, &rhs_denom.iter().collect::<Vec<&z3::ast::Bool>>());
-        let lhs_errors =
-            z3::ast::Bool::or(&ctx, &lhs_denom.iter().collect::<Vec<&z3::ast::Bool>>());
-        let error_preserved = rhs_errors.iff(&lhs_errors);
-        let assertion = z3::ast::Bool::and(&ctx, &[&assert_equal, &error_preserved]);
+            let rhs_errors = z3::ast::Bool::or(&rhs_denom.clone());
+            let lhs_errors = z3::ast::Bool::or(&lhs_denom.clone());
+            let error_preserved = rhs_errors.iff(&lhs_errors);
+            let assertion = z3::ast::Bool::and(&[assert_equal, error_preserved]);
 
-        solver.assert(&assertion.clone().not());
-        let res = Self::z3_res_to_validationresult(solver.check());
-        /*if let ValidationResult::Valid = res {
-            eprintln!("verifying {} => {}", lhs, rhs);
-        eprintln!("assertion: {}", assertion);
-        }*/
-        res
+            solver.assert(&assertion.clone().not());
+            Self::z3_res_to_validationresult(solver.check())
+        })
     }
 
     fn is_constant(&self) -> bool {
@@ -214,16 +206,15 @@ impl SynthLanguage for Math {
 }
 
 impl Math {
-    fn _one_of_errors(ctx: &z3::Context, denoms: HashSet<String>) -> z3::ast::Bool {
-        let zero_z3 = z3::ast::Real::from_real(&ctx, 0, 1);
+    fn _one_of_errors(denoms: HashSet<String>) -> z3::ast::Bool {
+        let zero_z3 = z3::ast::Real::from_real(0, 1);
 
-        let mut one_of_rhs_errors = z3::ast::Bool::from_bool(ctx, false);
+        let mut one_of_rhs_errors = z3::ast::Bool::from_bool(false);
         for d in denoms {
             let expr = egg_to_z3(
-                ctx,
                 Self::instantiate(&d.to_string().parse::<Pattern<Math>>().unwrap()).as_ref(),
             );
-            one_of_rhs_errors = z3::ast::Bool::or(ctx, &[&one_of_rhs_errors, &expr._eq(&zero_z3)]);
+            one_of_rhs_errors = z3::ast::Bool::or(&[one_of_rhs_errors, expr.eq(&zero_z3)]);
         }
         one_of_rhs_errors
     }
@@ -323,43 +314,41 @@ impl Math {
     /// For example,
     /// In (if x y z), the expression y
     /// has condition (!= x 0)
-    fn error_conditions<'a>(
-        ctx: &'a z3::Context,
+    fn error_conditions(
         sexp: Sexp,
-        path: z3::ast::Bool<'a>,
-    ) -> Vec<z3::ast::Bool<'a>> {
-        let mut res = Vec::<z3::ast::Bool<'a>>::default();
+        path: z3::ast::Bool,
+    ) -> Vec<z3::ast::Bool> {
+        let mut res = Vec::<z3::ast::Bool>::default();
         match sexp {
             Sexp::List(list) => {
                 if list[0] == Sexp::String("/".to_string()) {
                     let denom = list[2].to_string();
                     let expr = egg_to_z3(
-                        &ctx,
                         Self::instantiate(&denom.to_string().parse::<Pattern<Math>>().unwrap())
                             .as_ref(),
                     );
-                    let is_zero = expr._eq(&z3::ast::Real::from_real(ctx, 0, 1));
+                    let is_zero = expr.eq(&z3::ast::Real::from_real(0, 1));
 
-                    res.push(z3::ast::Bool::and(ctx, &[&is_zero, &path]));
+                    res.push(z3::ast::Bool::and(&[is_zero, path.clone()]));
                 }
 
                 if list[0] == Sexp::String("if".to_string()) {
                     let cond_real = egg_to_z3(
-                        &ctx,
                         Self::instantiate(&list[1].to_string().parse::<Pattern<Math>>().unwrap())
                             .as_ref(),
                     );
-                    let zero = z3::ast::Real::from_real(ctx, 0, 1);
-                    let new_path_pos = z3::ast::Bool::and(
-                        &ctx,
-                        &[&path, &z3::ast::Bool::not(&cond_real._eq(&zero))],
-                    );
-                    let new_path_neg = z3::ast::Bool::and(&ctx, &[&path, &cond_real._eq(&zero)]);
-                    res.extend(Self::error_conditions(ctx, list[2].clone(), new_path_pos));
-                    res.extend(Self::error_conditions(ctx, list[3].clone(), new_path_neg));
+                    let zero = z3::ast::Real::from_real(0, 1);
+                    let new_path_pos = z3::ast::Bool::and(&[
+                        path.clone(),
+                        cond_real.eq(&zero).not(),
+                    ]);
+                    let new_path_neg =
+                        z3::ast::Bool::and(&[path.clone(), cond_real.eq(&zero)]);
+                    res.extend(Self::error_conditions(list[2].clone(), new_path_pos));
+                    res.extend(Self::error_conditions(list[3].clone(), new_path_neg));
                 } else {
                     for s in list {
-                        res.extend(Self::error_conditions(ctx, s, path.clone()));
+                        res.extend(Self::error_conditions(s, path.clone()));
                     }
                 };
             }
@@ -437,50 +426,42 @@ impl Math {
     }
 }
 
-fn egg_to_z3<'a>(ctx: &'a z3::Context, expr: &[Math]) -> z3::ast::Real<'a> {
+fn egg_to_z3(expr: &[Math]) -> z3::ast::Real {
     let mut buf: Vec<z3::ast::Real> = vec![];
     for node in expr.as_ref().iter() {
         match node {
-            Math::Add([x, y]) => buf.push(z3::ast::Real::add(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
-            Math::Sub([x, y]) => buf.push(z3::ast::Real::sub(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
-            Math::Mul([x, y]) => buf.push(z3::ast::Real::mul(
-                ctx,
-                &[&buf[usize::from(*x)], &buf[usize::from(*y)]],
-            )),
-            Math::Div([x, y]) => buf.push(z3::ast::Real::div(
-                &buf[usize::from(*x)],
-                &buf[usize::from(*y)],
-            )),
-            Math::Neg(x) => buf.push(z3::ast::Real::unary_minus(&buf[usize::from(*x)])),
+            Math::Add([x, y]) => buf.push(z3::ast::Real::add(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
+            Math::Sub([x, y]) => buf.push(z3::ast::Real::sub(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
+            Math::Mul([x, y]) => buf.push(z3::ast::Real::mul(&[
+                buf[usize::from(*x)].clone(),
+                buf[usize::from(*y)].clone(),
+            ])),
+            Math::Div([x, y]) => {
+                let l = buf[usize::from(*x)].clone();
+                let r = buf[usize::from(*y)].clone();
+                buf.push(l.div(&r));
+            }
+            Math::Neg(x) => buf.push(buf[usize::from(*x)].unary_minus()),
             Math::Abs(a) => {
-                let inner = &buf[usize::from(*a)].clone();
-                let zero = z3::ast::Real::from_real(ctx, 0, 1);
-                buf.push(z3::ast::Bool::ite(
-                    &z3::ast::Real::le(inner, &zero),
-                    &z3::ast::Real::unary_minus(inner),
-                    &inner,
-                ));
+                let inner = buf[usize::from(*a)].clone();
+                let zero = z3::ast::Real::from_real(0, 1);
+                buf.push(inner.le(&zero).ite(&inner.unary_minus(), &inner));
             }
             Math::Lit(c) => buf.push(z3::ast::Real::from_real(
-                ctx,
                 (c.numer()).to_i32().unwrap(),
                 (c.denom()).to_i32().unwrap(),
             )),
-            Math::Var(v) => buf.push(z3::ast::Real::new_const(ctx, v.to_string())),
+            Math::Var(v) => buf.push(z3::ast::Real::new_const(v.to_string())),
             Math::If([x, y, z]) => {
-                let zero = z3::ast::Real::from_real(ctx, 0, 1);
-                let cond = z3::ast::Bool::not(&buf[usize::from(*x)]._eq(&zero));
-                buf.push(z3::ast::Bool::ite(
-                    &cond,
-                    &buf[usize::from(*y)],
-                    &buf[usize::from(*z)],
-                ))
+                let zero = z3::ast::Real::from_real(0, 1);
+                let cond = buf[usize::from(*x)].eq(&zero).not();
+                buf.push(cond.ite(&buf[usize::from(*y)], &buf[usize::from(*z)]))
             }
         }
     }

--- a/tests/rational.rs
+++ b/tests/rational.rs
@@ -171,14 +171,10 @@ impl SynthLanguage for Math {
             let solver = z3::Solver::new();
             let lexpr = egg_to_z3(Self::instantiate(lhs).as_ref());
             let rexpr = egg_to_z3(Self::instantiate(rhs).as_ref());
-            let lhs_denom = Self::error_conditions(
-                Self::pat_to_sexp(lhs),
-                z3::ast::Bool::from_bool(true),
-            );
-            let rhs_denom = Self::error_conditions(
-                Self::pat_to_sexp(rhs),
-                z3::ast::Bool::from_bool(true),
-            );
+            let lhs_denom =
+                Self::error_conditions(Self::pat_to_sexp(lhs), z3::ast::Bool::from_bool(true));
+            let rhs_denom =
+                Self::error_conditions(Self::pat_to_sexp(rhs), z3::ast::Bool::from_bool(true));
 
             let mut assert_equal = lexpr.eq(&rexpr);
 
@@ -314,10 +310,7 @@ impl Math {
     /// For example,
     /// In (if x y z), the expression y
     /// has condition (!= x 0)
-    fn error_conditions(
-        sexp: Sexp,
-        path: z3::ast::Bool,
-    ) -> Vec<z3::ast::Bool> {
+    fn error_conditions(sexp: Sexp, path: z3::ast::Bool) -> Vec<z3::ast::Bool> {
         let mut res = Vec::<z3::ast::Bool>::default();
         match sexp {
             Sexp::List(list) => {
@@ -338,12 +331,9 @@ impl Math {
                             .as_ref(),
                     );
                     let zero = z3::ast::Real::from_real(0, 1);
-                    let new_path_pos = z3::ast::Bool::and(&[
-                        path.clone(),
-                        cond_real.eq(&zero).not(),
-                    ]);
-                    let new_path_neg =
-                        z3::ast::Bool::and(&[path.clone(), cond_real.eq(&zero)]);
+                    let new_path_pos =
+                        z3::ast::Bool::and(&[path.clone(), cond_real.eq(&zero).not()]);
+                    let new_path_neg = z3::ast::Bool::and(&[path.clone(), cond_real.eq(&zero)]);
                     res.extend(Self::error_conditions(list[2].clone(), new_path_pos));
                     res.extend(Self::error_conditions(list[3].clone(), new_path_neg));
                 } else {


### PR DESCRIPTION
(Code by Claude)

API migration:
- Cargo feature `static-link-z3` was renamed `bundled`.
- AST types lost their lifetime parameter: `z3::ast::Int<'a>` → `z3::ast::Int`
- All AST constructors no longer take `&Context`: `Int::from_i64(&ctx, 0)` → `Int::from_i64(0)` `BV::new_const(&ctx, name, n)` → `BV::new_const(name, n)` `Real::from_real(&ctx, 1, 2)` → `Real::from_real(1, 2)` `Bool::from_bool(&ctx, true)` → `Bool::from_bool(true)`
- Variadic ops drop the `&Context` argument: `Int::add(&ctx, &[&a, &b])` → `Int::add(&[a.clone(), b.clone()])` Same for `Bool::and` / `Bool::or` / `Real::add` / etc. The slice element bound changed to `T: Into<Self> + Clone`, so we clone where we previously passed `&T`.
- Binops are now methods on the receiver instead of free functions: `Int::lt(l, r)` → `l.lt(r)` `Bool::ite(&cond, &a, &b)` → `cond.ite(&a, &b)`
- `Solver::new(&ctx)` → `Solver::new()` (no args).
- `Context::new(&cfg)` is gone; wrap solver work in `z3::with_z3_config(&cfg, || { ... })`, which scopes a thread-local context for the closure body.
- `_eq` is deprecated in favor of `eq` (still works with a warning).